### PR TITLE
Restore the weekly Renovate window

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,29 +19,29 @@
 
   timezone: "America/Toronto",
 
-  // TEMPORARY. Restore `schedule: ["before 7am on Monday"]` when the CodeRabbit
-  // question below is settled.
+  // One window a week for creating branches, so the pull requests arrive
+  // together rather than trickling in.
   //
-  // Why it is off: on 2026-08-17 three dependency bot pull requests went more
-  // than ten hours without a CodeRabbit review, a comment, or even a
-  // `CodeRabbit` status, while every human pull request that day got one within
-  // minutes. Asked directly, CodeRabbit answered #56 in under three minutes, so
-  // the capability is there. GitHub also ran a critical incident that day,
-  // 13:40Z to 21:15Z, with Webhooks among the affected components, which would
-  // produce exactly that silence, so the observation is unusable and has to be
-  // repeated on a clean day.
+  // Only creating. updateNotScheduled defaults to true, so branches that
+  // already exist are still rebased outside the window, which matters here
+  // because required checks are strict: every merge puts the other open pull
+  // requests behind, and they would sit until the next Monday if Renovate could
+  // not touch them. This was misread once as a reason not to restore the window
+  // at all.
   //
-  // Repeating it needs a bot pull request, and the weekly window is what stops
-  // one existing: it only permits branch creation between midnight and 7am on a
-  // Monday, so the next natural opportunity is a week away. Nothing else about
-  // the policy moves. minimumReleaseAge still holds every update for seven
-  // days, and prConcurrentLimit and prHourlyLimit still bound how much arrives
-  // at once.
+  // Lifted briefly on 2026-08-18 to produce a bot pull request on demand, which
+  // is the only way to observe whether CodeRabbit auto-reviews one. It does not.
+  // Across 16 bot pull requests it posted a `CodeRabbit` status on exactly one,
+  // #56, which is the one asked by hand, while all 8 human pull requests in the
+  // same window got one automatically. GitHub's 2026-08-17 webhook incident is
+  // ruled out, since the retest ran hours after it resolved. Raised with their
+  // support.
   //
-  // Worth weighing before restoring it: the window costs up to seven days on
-  // top of the seven the cooling period already imposes, and it was there to
-  // give a person one sitting a week to work through the batch. Nothing is
+  // Worth weighing if this is ever reconsidered: the window costs up to seven
+  // days on top of the seven minimumReleaseAge already imposes, and it existed
+  // to give a person one sitting a week to work through the batch. Nothing is
   // worked through by hand any more.
+  schedule: ["before 7am on Monday"],
 
   labels: ["dependencies", "docker"],
   commitMessagePrefix: "chore:",


### PR DESCRIPTION
The window was lifted in #60 to produce a bot pull request on demand, which was the only way to observe whether CodeRabbit auto-reviews one. That question is answered, so it goes back.

## What the experiment found

| | `CodeRabbit` status present |
|---|---|
| Human PRs (#57, #58, #59, #60, #63, #68, #69, #74) | 8 of 8 |
| Bot PRs (#53 through #76) | 1 of 16 |

The single exception is #56, which is the one I asked for by hand with `@coderabbitai review`, and it answered in under three minutes. Four of the human statuses read "Review rate limited", which is what rules out quota as the explanation: a throttled review still reports a status, whereas the bot PRs report nothing at all. Raised with CodeRabbit support.

## A correction recorded in the comment

I held this change back twice on the belief that restoring the window would freeze the open bot PRs until Monday, because strict checks mean every merge puts the others behind and they would need a rebase. That was wrong. `updateNotScheduled` defaults to `true`, so the schedule restricts *creating* branches, not updating existing ones, and Renovate keeps rebasing open pull requests outside the window. The comment in the file now says so, since the mistake is an easy one to repeat.

## Not changed

`.github/dependabot.yml` was never touched by any of this work, so there is nothing to restore there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renovate updates are now scheduled to create branches before 7am on Mondays.
  * Added documentation clarifying update behavior, scheduling costs, and support escalation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->