### PR TITLE
Fix the pre-commit pin lookups, and resync checkov

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -250,6 +250,36 @@
     },
     {
       customType: "regex",
+      // The `additional_dependencies` pins in .pre-commit-config.yaml: gitleaks
+      // (a Go module) and checkov (a pypi package). Neither is a container
+      // image, which is the whole reason this is its own manager.
+      //
+      // These used to sit alongside the image patterns below, under that
+      // manager's `datasourceTemplate: "docker"`. A template set on a manager
+      // applies to every one of its matchStrings and wins over a `datasource`
+      // captured by the pattern, so the annotations here were read and then
+      // overridden, and Renovate spent weeks reporting:
+      //
+      //   Failed to look up docker package github.com/zricethezav/gitleaks/v8
+      //   Failed to look up docker package checkov
+      //
+      // Silently, on the repository's Renovate dashboard rather than anywhere
+      // this repository would notice. Meanwhile the second copy of the checkov
+      // pin, in the workflow, updates through a different manager that has no
+      // template, so the two drifted: the gate was still on 3.3.2 while the
+      // SARIF report had reached 3.3.10. That is exactly the failure the
+      // manager below warns about.
+      //
+      // No datasourceTemplate here, deliberately. The annotation is the
+      // authority, and it is the only thing that can be, because the two
+      // dependencies do not share a datasource.
+      managerFilePatterns: ["/^\\.pre-commit-config\\.yaml$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*additional_dependencies: \\[\"[^\"]+?(?:==|@)(?<currentValue>v?[0-9][^\"]*)\"\\]",
+      ],
+    },
+    {
+      customType: "regex",
       // Versions pinned inside `repo: local` hooks in .pre-commit-config.yaml.
       //
       // Dependabot's pre-commit ecosystem updates the `rev:` of a hook
@@ -280,7 +310,6 @@
         "/^\\.github/workflows/pull-request-validation\\.yml$/",
       ],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*additional_dependencies: \\[\"[^\"]+?(?:==|@)(?<currentValue>v?[0-9][^\"]*)\"\\]",
         "# renovate: datasource=docker depName=(?<depName>aquasec/trivy)[\\s\\S]{0,900}?aquasec/trivy:(?<currentValue>v?\\d[\\w.\\-]*)",
         "# renovate: datasource=docker depName=(?<depName>dotenvlinter/dotenv-linter)[\\s\\S]{0,900}?dotenvlinter/dotenv-linter:(?<currentValue>v?\\d[\\w.\\-]*)",
         "# renovate: datasource=docker depName=(?<depName>zricethezav/gitleaks)[\\s\\S]{0,900}?zricethezav/gitleaks:(?<currentValue>v?\\d[\\w.\\-]*)",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -349,7 +349,7 @@ repos:
           --directory .
         language: python
         # renovate: datasource=pypi depName=checkov
-        additional_dependencies: ["checkov==3.3.2"]
+        additional_dependencies: ["checkov==3.3.10"]
         stages: [pre-push]
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
Renovate's dashboard has been reporting two lookup failures:

```
Failed to look up docker package github.com/zricethezav/gitleaks/v8
Failed to look up docker package checkov
Files affected: .pre-commit-config.yaml
```

## Why

Neither is a container image. They are the `additional_dependencies` pins in `.pre-commit-config.yaml`, a Go module and a pypi package, and their annotations say exactly that. They sat in the same custom manager as five image patterns, under that manager's `datasourceTemplate: "docker"`. **A template set on a manager applies to every one of its matchStrings and wins over a `datasource` captured by the pattern**, so the annotations were read and then discarded.

Verified by running the pattern against the real file:

```
datasource=go     depName=github.com/zricethezav/gitleaks/v8   currentValue=v8.30.1
datasource=pypi   depName=checkov                              currentValue=3.3.10
```

Both correct, both being overridden to `docker`.

## Why it is not just a warning

The checkov pin exists twice: once in `.pre-commit-config.yaml`, which is the gate, and once in `pull-request-validation.yml`, which produces the SARIF report. The workflow copy updates through a different manager that has no template, so it kept moving while this one could not:

| | version |
|---|---|
| `.pre-commit-config.yaml` (the gate) | 3.3.2 |
| `pull-request-validation.yml` (the report) | 3.3.10 |

That manager's own comment says the two copies have to move together "or the reports stop describing what the gate actually enforces". Turning on automerge made it worse rather than causing it: every checkov bump that merged widened the gap, since only one side could resolve.

## The fix

The annotation-driven pattern moves into its own manager with no `datasourceTemplate`, so the captured datasource is what gets used. The image patterns keep theirs.

The gate is resynced to 3.3.10 by hand this once, since Renovate would otherwise not offer it until the next Monday window. Confirmed the newer version still passes:

```
$ pre-commit run checkov --all-files --hook-stage pre-push
Scan the repository for infrastructure misconfiguration.......................Passed
```

gitleaks was already `v8.30.1` on both sides, so only checkov had drifted.

## Worth noting

This failure was visible only on Renovate's own dashboard, which nothing in this repository looks at. The `Renovate Config` job validates the file's schema and would never catch it, because the config is valid, it just does the wrong thing. Worth deciding separately whether that dashboard should be checked periodically.