### PR TITLE
fix: approve grouped Dependabot bumps and add a workflow_dispatch recovery lever

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -60,41 +60,166 @@ on:
   workflow_run:
     workflows: ["CodeRabbit Gate"]
     types: [completed]
+  # The recovery lever, for the `resolve-bot`/`approve` jobs below only.
+  # Neither `pull_request_target` above fires again once a pull request stops
+  # changing, so a bot pull request that was already open when this file's own
+  # decision changed has no future event left to earn an approval from. #94
+  # and #136 were both stranded exactly that way; #136 was only recovered by
+  # closing and reopening it, which is a clumsy lever to ask of a maintainer.
+  #
+  # `pr_number` follows pull-request-validation.yml's own workflow_dispatch
+  # shape: optional, so leaving it blank re-checks every open Dependabot or
+  # Renovate pull request instead of one. It is validated as digits-only in
+  # `resolve-bot` below before it ever reaches an API path, since this is free
+  # text a maintainer types by hand, unlike github.event.pull_request.number,
+  # which GitHub has already parsed for us.
+  #checkov:skip=CKV_GHA_7:workflow_dispatch itself requires write access to
+  # trigger at all (GitHub platform-level gate, not something this file
+  # controls); pr_number never selects a checkout ref or anything else that
+  # runs, unlike pull-request-validation.yml's own input, since the checkout
+  # below always resolves to the default branch. It only ever selects which
+  # pull request a read-only `gh api` lookup and, if the decision below
+  # approves, `gh pr review`/`gh pr merge --auto` act on, matched against
+  # digits before either happens.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: >-
+          Pull request number to re-run the approval decision for. Leave
+          blank to check every open Dependabot or Renovate pull request.
+        required: false
 
 # The floor. Each job widens it for itself.
 permissions:
   contents: read
 
 jobs:
+  resolve-bot:
+    name: Find the bot pull request(s) to check
+    # Not `workflow_run`: that trigger exists for `resolve-owner`/
+    # `approve-owner` below only, and this job's case statement has no branch
+    # for it. Excluded here rather than given a no-op branch, so an
+    # unhandled-event failure below stays meaningful if this file ever grows
+    # another trigger nobody taught this job about.
+    if: github.event_name != 'workflow_run'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: read
+    outputs:
+      # A JSON array of {pr_number}, the same shape resolve-owner below
+      # already outputs and for the same reason: the approve job re-reads
+      # each pull request fresh from the number, so nothing else is worth
+      # carrying through the matrix.
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - name: Build the list of bot pull requests to check
+        id: build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request_target)
+              # Read straight off the immutable payload: cheap, and this is
+              # the same trust boundary this job's own predecessor already
+              # relied on. user.login is set by GitHub from the authenticated
+              # author, so a pull request cannot claim to be a bot. Exact
+              # equality, not startsWith or contains: `renovate[bot]-x` is a
+              # login somebody may register, and the non-fork condition is the
+              # second half of the same fence, since reaching this any other
+              # way would take write access to this repository.
+              #
+              # The label condition is about noise rather than correctness.
+              # `labeled` fires once per label, Renovate applies three, and
+              # with `opened` as well #61 collected seven identical approvals
+              # before anything had even run. Only the label actually read
+              # below is worth waking this for.
+              if [ "$IS_FORK" = "false" ] \
+                && { [ "$PR_AUTHOR" = "renovate[bot]" ] || [ "$PR_AUTHOR" = "dependabot[bot]" ]; } \
+                && { [ "$EVENT_ACTION" != "labeled" ] || [ "$LABEL_NAME" = "automerge" ]; }; then
+                matrix=$(jq -nc --arg n "$PR_NUMBER" '[{pr_number: ($n | tonumber)}]')
+              else
+                matrix='[]'
+              fi
+              ;;
+
+            workflow_dispatch)
+              if [ -n "$INPUT_PR_NUMBER" ]; then
+                # Digits only, checked before this ever reaches an API path
+                # below: unlike github.event.pull_request.number, which
+                # GitHub has already parsed for us, a workflow_dispatch input
+                # is free text a maintainer types by hand.
+                if ! [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+                  echo "::error::pr_number must be digits only, got '$INPUT_PR_NUMBER'."
+                  exit 1
+                fi
+                matrix=$(jq -nc --arg n "$INPUT_PR_NUMBER" '[{pr_number: ($n | tonumber)}]')
+              else
+                # The REST list endpoint, not `gh pr list`: its GraphQL-backed
+                # --json author reports a bot's login as "app/dependabot", not
+                # the "dependabot[bot]" shape every other author check in this
+                # file compares against, confirmed live against this
+                # repository's own open pull requests. REST's `.user.login`
+                # matches what github.event.pull_request.user.login reports on
+                # the pull_request_target path above, so both triggers agree
+                # on what a bot's login looks like.
+                matrix=$(gh api "repos/$REPO/pulls?state=open&per_page=100" \
+                  --jq '[.[] | select((.user.login == "renovate[bot]" or .user.login == "dependabot[bot]")
+                                  and .head.repo.fork == false)
+                          | {pr_number: .number}]')
+              fi
+              ;;
+
+            *)
+              echo "::error::Unhandled event: $EVENT_NAME"
+              exit 1
+              ;;
+          esac
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Checking: $matrix"
+
   approve:
     name: Approve and enable auto-merge
-    # user.login is set by GitHub from the authenticated author, so a pull
-    # request cannot claim to be a bot. Exact equality, not startsWith or
-    # contains: `renovate[bot]-x` is a login somebody may register, and the
-    # non-fork condition is the second half of the same fence, since reaching
-    # this job any other way would take write access to this repository.
+    needs: resolve-bot
+    # An empty array is not an error: nothing resolved to check, and nothing
+    # to approve. `fromJson('[]')` still starts a matrix with zero jobs, which
+    # reports as success on its own with no step of this job ever running,
+    # the same reasoning approve-owner below already relies on.
     #
-    # The label condition is about noise rather than correctness. `labeled`
-    # fires once per label, Renovate applies three, and with `opened` as well
-    # #61 collected seven identical approvals before anything had even run. Only
-    # the label this job actually reads is worth waking it for.
-    if: >-
-      github.event.pull_request.head.repo.fork == false && (
-        github.event.pull_request.user.login == 'renovate[bot]' ||
-        github.event.pull_request.user.login == 'dependabot[bot]'
-      ) && (
-        github.event.action != 'labeled' ||
-        github.event.label.name == 'automerge'
-      )
+    # `resolve-bot.result == 'success'` matters as much as the matrix check:
+    # resolve-bot is deliberately skipped on `workflow_run` above, and a
+    # custom `if:` here opts this job out of GitHub's own implicit
+    # "needs succeeded" gate, so a skipped predecessor is not screened out on
+    # its own. Without this, `needs.resolve-bot.outputs.matrix` reads as
+    # empty rather than `'[]'` for a skipped run, `!= '[]'` is still true, and
+    # `fromJson('')` below would fail the job outright on every `workflow_run`
+    # trigger.
+    if: needs.resolve-bot.result == 'success' && needs.resolve-bot.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # One at a time per pull request. The guard below reads the reviews and then
-    # writes one, so two runs racing between those two steps would both see no
-    # approval and both add one, which is the pile-up this is meant to end.
-    # Queued rather than cancelled: a superseded run here has nothing to redo,
-    # but a cancelled one might have been the only run that would have approved.
+    strategy:
+      fail-fast: false
+      matrix:
+        entry: ${{ fromJson(needs.resolve-bot.outputs.matrix) }}
+    # One at a time per pull request. The guard in the Approve step below
+    # reads the reviews and then writes one, so two runs racing between those
+    # two steps would both see no approval and both add one, which is the
+    # pile-up this is meant to end. Queued rather than cancelled: a
+    # superseded run here has nothing to redo, but a cancelled one might have
+    # been the only run that would have approved.
     concurrency:
-      group: bot-auto-merge-${{ github.event.pull_request.number }}
+      group: bot-auto-merge-${{ matrix.entry.pr_number }}
       cancel-in-progress: false
     permissions:
       # For `gh pr merge --auto` on the Dependabot path only. Arming auto-merge
@@ -106,12 +231,36 @@ jobs:
       - name: Check out the default branch
         uses: actions/checkout@v7
         with:
-          # Explicitly the base branch, which is also what pull_request_target
-          # checks out by default. Stated anyway, because the assertion below is
-          # only worth running if it is this repository's copy of it and not the
-          # pull request's, and a default is a poor place to keep that.
-          ref: ${{ github.event.pull_request.base.ref }}
+          # The repository's default branch, not
+          # github.event.pull_request.base.ref: that context is absent on
+          # workflow_dispatch, and every trigger this job runs under targets
+          # `main` as the base anyway (see the pull_request_target filter
+          # above), so this is not a behavior change on that path.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+
+      - name: Read the pull request's metadata
+        # Stands in for github.event.pull_request.* everywhere below, since
+        # that context only exists on the pull_request_target path;
+        # workflow_dispatch carries nothing but the number resolve-bot put in
+        # the matrix. Read fresh from the API on every trigger rather than
+        # branching per event, the same choice coderabbit-gate.yml's grade job
+        # makes for the same reason: one source of truth for what this pull
+        # request currently looks like, not two that can disagree.
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ matrix.entry.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/pulls/$PR_NUMBER" | jq -r '
+            "author=" + .user.login,
+            "html_url=" + .html_url,
+            "head_sha=" + .head.sha,
+            "has_automerge_label=" + ([.labels[].name] | any(. == "automerge") | tostring)
+          ' >> "$GITHUB_OUTPUT"
 
       - name: Wait for the published pin-only verdict
         # The check that keeps "approve on the strength of the author" from
@@ -131,7 +280,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -152,10 +301,43 @@ jobs:
           echo "::error::No settled Pin Only verdict for $HEAD_SHA after two minutes."
           exit 1
 
+      - name: Synthesize a pull_request event payload
+        # dependabot/fetch-metadata reads github.event.pull_request straight
+        # off the event payload file and throws "Event payload missing
+        # `pull_request` key" when it is absent, confirmed by reading its
+        # source (dist/index.js): getMessage, getBranchNames, getBody and
+        # getTitle all destructure context.payload.pull_request with no other
+        # fallback. workflow_dispatch carries no such key. The REST pull
+        # request resource read above has the same shape as the webhook
+        # payload the action expects, which is what makes wrapping it in
+        # {"pull_request": ...} and pointing GITHUB_EVENT_PATH at it for the
+        # next step a substitution the action cannot tell apart from the real
+        # thing.
+        if: github.event_name == 'workflow_dispatch' && steps.pr.outputs.author == 'dependabot[bot]'
+        id: synth_event
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ matrix.entry.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          path="$RUNNER_TEMP/pr-$PR_NUMBER-event.json"
+          gh api "repos/$REPO/pulls/$PR_NUMBER" | jq '{pull_request: .}' > "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
       - name: Fetch Dependabot metadata
         id: metadata
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        if: steps.pr.outputs.author == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        env:
+          # The real event payload on pull_request_target; the synthetic one
+          # from the step above on workflow_dispatch, which carries no
+          # pull_request key of its own. github.event_path, not a bare
+          # $GITHUB_EVENT_PATH default: this workflow never sets that variable
+          # itself, so there is no runner default to fall back on other than
+          # the one GitHub already exposes through this context.
+          GITHUB_EVENT_PATH: ${{ github.event_name == 'workflow_dispatch' && steps.synth_event.outputs.path || github.event_path }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -180,11 +362,31 @@ jobs:
         # metadata action. All three of its ecosystems are eligible, test
         # requirements included: they only reach the test virtualenv, and the
         # suite is what clears them either way.
+        #
+        # `update-type` is blank for a grouped update (#94, "bump the
+        # test-dependencies group ... with 2 updates"): confirmed live from
+        # that pull request's own run, fetch-metadata has no single semver
+        # level to report for more than one dependency, and this
+        # organization's every repository groups its pre-commit and
+        # github-actions ecosystems with `patterns: ["*"]`, so a grouped bump
+        # is the normal shape, not an edge case, and the patch-or-minor branch
+        # below had been permanently unreachable for Dependabot.
+        # `updated-dependencies-json` is the fallback fetch-metadata itself
+        # documents for exactly this: one entry per dependency, each carrying
+        # its own updateType, so the group is approved only when every single
+        # entry is itself a patch or minor bump; a group hiding even one major
+        # still waits for review. #94 stays unapproved even with this fix in
+        # place: it is a pip "permit the latest version" style update whose
+        # commit message states no prior version for either dependency, so
+        # fetch-metadata cannot compute an update type for either entry at all
+        # (each reports "" confirmed live), and the fallback below correctly
+        # reads that as unresolved rather than as a bump it can vouch for.
         id: decide
         env:
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          HAS_AUTOMERGE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'automerge') }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+          HAS_AUTOMERGE_LABEL: ${{ steps.pr.outputs.has_automerge_label }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
         run: |
           approve=false
           arm=false
@@ -204,6 +406,40 @@ jobs:
                   # Dependabot cannot arm auto-merge itself, unlike Renovate.
                   arm=true
                   ;;
+                "")
+                  # A grouped update: fall back to updated-dependencies-json
+                  # and require every dependency in it to be a patch or minor
+                  # bump on its own. Piped in on stdin rather than
+                  # interpolated into the jq program text, so nothing about a
+                  # dependency's name or version is ever read as jq syntax.
+                  #
+                  # shellcheck disable=SC2016
+                  result=$(printf '%s' "$UPDATED_DEPENDENCIES_JSON" | jq -r '
+                      def ok: . == "version-update:semver-patch" or . == "version-update:semver-minor";
+                      if (type != "array") or length == 0 then
+                        "false\tno updated-dependencies-json to fall back on"
+                      else
+                        ([.[].updateType | if . == "" or . == null then "unknown" else . end]) as $types
+                        | if ($types | all(ok)) then
+                            "true\tevery dependency in the group is a patch or minor bump (\($types | join(", ")))"
+                          else
+                            "false\tnot every dependency in the group is a patch or minor bump (\($types | join(", ")))"
+                          end
+                      end
+                    ' 2>/dev/null || echo "")
+                  if [ -z "$result" ]; then
+                    result="false"$'\t'"updated-dependencies-json was empty or could not be parsed as JSON"
+                  fi
+                  IFS=$'\t' read -r group_ok group_reason <<< "$result"
+                  if [ "$group_ok" = "true" ]; then
+                    approve=true
+                    # Dependabot cannot arm auto-merge itself, unlike Renovate.
+                    arm=true
+                    echo "::notice::Update type is blank (a grouped update); $group_reason."
+                  else
+                    echo "::notice::Update type is blank (a grouped update), and $group_reason, so it waits for review."
+                  fi
+                  ;;
                 *)
                   echo "::notice::Update type ${UPDATE_TYPE:-unknown} is not a patch or minor bump, so it waits for review."
                   ;;
@@ -218,8 +454,8 @@ jobs:
         if: steps.decide.outputs.approve == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ steps.pr.outputs.html_url }}
+          PR_NUMBER: ${{ matrix.entry.pr_number }}
           REPO: ${{ github.repository }}
         # Re-approved on every push, which is required rather than wasteful:
         # branch protection dismisses stale reviews, so a rebase drops the
@@ -252,11 +488,17 @@ jobs:
         if: steps.decide.outputs.arm == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_URL: ${{ steps.pr.outputs.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
 
   resolve-owner:
     name: Find the owner's pull request to approve
+    # Not `workflow_dispatch`: that trigger exists for the bot path above
+    # only, and this job's case statement below has no branch for it. The
+    # recovery lever is for a stranded bot pull request; the owner's own
+    # already has `workflow_run` re-running this on every CodeRabbit Gate
+    # completion, so there is nothing here for a manual dispatch to recover.
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -325,7 +567,16 @@ jobs:
     # An empty array is not an error: nothing to check in, and nothing to
     # approve. `fromJson('[]')` still starts a matrix with zero jobs, which
     # reports as success on its own with no step of this job ever running.
-    if: needs.resolve-owner.outputs.matrix != '[]'
+    #
+    # `resolve-owner.result == 'success'` matters as much as the matrix check:
+    # resolve-owner is now deliberately skipped on `workflow_dispatch` above,
+    # and a custom `if:` here opts this job out of GitHub's own implicit
+    # "needs succeeded" gate, so a skipped predecessor is not screened out on
+    # its own. Without this, `needs.resolve-owner.outputs.matrix` reads as
+    # empty rather than `'[]'` for a skipped run, `!= '[]'` is still true, and
+    # `fromJson('')` below would fail this job outright on every manual
+    # dispatch of the bot recovery lever.
+    if: needs.resolve-owner.result == 'success' && needs.resolve-owner.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -362,6 +362,19 @@ jobs:
         run: |
           set -euo pipefail
           jq '{pull_request: .}' "$RESOURCE" > "$GITHUB_EVENT_PATH"
+          echo "DEBUG event_path=$GITHUB_EVENT_PATH"
+          echo "DEBUG contents:"
+          cat "$GITHUB_EVENT_PATH"
+          echo "DEBUG ls -la:"
+          ls -la "$GITHUB_EVENT_PATH"
+
+      - name: DEBUG recheck event path in a fresh step
+        if: steps.pr.outputs.author == 'dependabot[bot]'
+        shell: bash
+        run: |
+          echo "DEBUG2 event_path=$GITHUB_EVENT_PATH"
+          echo "DEBUG2 contents:"
+          cat "$GITHUB_EVENT_PATH"
 
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -627,16 +627,19 @@ jobs:
         #
         # What is left, and what this step does, is grade a Renovate pull
         # request directly: unlike Dependabot's, that decision was already
-        # small (has the `automerge` label? not already approved?) and reads
-        # entirely off the API, no marketplace action involved, so
-        # duplicating it here is a bounded, low-risk copy rather than the
-        # kind that drifted before (see the Decide step's own comment in the
-        # `approve` job above). A Dependabot pull request cannot be graded
-        # this way: dependabot/fetch-metadata is the one thing here that
-        # only works on a real trigger, so this reports why and leaves
-        # closing and reopening the pull request, which is a genuine
-        # `reopened` trigger, as the still-clumsy but still-working lever
-        # for that half.
+        # small (has the `automerge` label, Pin Only still success, not
+        # already approved?) and reads entirely off the API, no marketplace
+        # action involved, so duplicating it here is a bounded, low-risk copy
+        # rather than the kind that drifted before (see the Decide step's own
+        # comment in the `approve` job above). The Pin Only check matters as
+        # much here as it does there: an automerge label is Renovate asking
+        # for this to merge, not a guarantee the diff is only a pin, and
+        # approving on the label alone would reopen the exact hole Pin Only
+        # exists to close. A Dependabot pull request cannot be graded this
+        # way: dependabot/fetch-metadata is the one thing here that only
+        # works on a real trigger, so this reports why and leaves closing and
+        # reopening the pull request, which is a genuine `reopened` trigger,
+        # as the still-clumsy but still-working lever for that half.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -689,6 +692,19 @@ jobs:
                 has_label=$(printf '%s' "$pr" | jq -r '[.labels[].name] | any(. == "automerge")')
                 if [ "$has_label" != "true" ]; then
                   echo "#$number: no automerge label, so Renovate is not asking for this to merge on its own."
+                  continue
+                fi
+                # The same guard the approve job always applies before
+                # approving anything: an automerge label says Renovate wants
+                # this merged, not that the diff is only a pin. Approving
+                # without this would let a Renovate pull request whose diff
+                # was not pin-only through on the strength of the label
+                # alone, which is exactly the hole Pin Only exists to close.
+                head_sha=$(printf '%s' "$pr" | jq -r '.head.sha')
+                pin_only_state=$(gh api "repos/$REPO/commits/$head_sha/status" \
+                  --jq '[.statuses[] | select(.context == "Pin Only")] | first | select(. != null) | .state // ""')
+                if [ "$pin_only_state" != "success" ]; then
+                  echo "#$number: Pin Only is ${pin_only_state:-absent}, not success, so this waits for review."
                   continue
                 fi
                 existing=$(gh api --paginate "repos/$REPO/pulls/$number/reviews" \

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -240,7 +240,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out the default branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The repository's default branch, not
           # github.event.pull_request.base.ref: that context is absent on
@@ -258,6 +258,12 @@ jobs:
         # branching per event, the same choice coderabbit-gate.yml's grade job
         # makes for the same reason: one source of truth for what this pull
         # request currently looks like, not two that can disagree.
+        #
+        # Written to a file, not just piped into this step's own jq: the
+        # Synthesize step below needs the identical resource, and reading it
+        # from the API a second time there would reopen the same
+        # "not two that can disagree" problem this step exists to close, one
+        # step later.
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -266,12 +272,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh api "repos/$REPO/pulls/$PR_NUMBER" | jq -r '
+          resource="$RUNNER_TEMP/pr-$PR_NUMBER.json"
+          gh api "repos/$REPO/pulls/$PR_NUMBER" > "$resource"
+          jq -r '
             "author=" + .user.login,
             "html_url=" + .html_url,
             "head_sha=" + .head.sha,
             "has_automerge_label=" + ([.labels[].name] | any(. == "automerge") | tostring)
-          ' >> "$GITHUB_OUTPUT"
+          ' "$resource" >> "$GITHUB_OUTPUT"
+          echo "resource=$resource" >> "$GITHUB_OUTPUT"
 
       - name: Wait for the published pin-only verdict
         # The check that keeps "approve on the strength of the author" from
@@ -319,22 +328,24 @@ jobs:
         # source (dist/index.js): getMessage, getBranchNames, getBody and
         # getTitle all destructure context.payload.pull_request with no other
         # fallback. workflow_dispatch carries no such key. The REST pull
-        # request resource read above has the same shape as the webhook
-        # payload the action expects, which is what makes wrapping it in
-        # {"pull_request": ...} and pointing GITHUB_EVENT_PATH at it for the
-        # next step a substitution the action cannot tell apart from the real
-        # thing.
+        # request resource the `pr` step above already saved has the same
+        # shape as the webhook payload the action expects, which is what
+        # makes wrapping it in {"pull_request": ...} and pointing
+        # GITHUB_EVENT_PATH at it for the next step a substitution the action
+        # cannot tell apart from the real thing. Built from that saved file
+        # rather than a second API call, so this can never read a pull
+        # request one push newer than what the `pr` step already committed to
+        # for every other output in this job.
         if: github.event_name == 'workflow_dispatch' && steps.pr.outputs.author == 'dependabot[bot]'
         id: synth_event
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+          RESOURCE: ${{ steps.pr.outputs.resource }}
           PR_NUMBER: ${{ matrix.entry.pr_number }}
         shell: bash
         run: |
           set -euo pipefail
           path="$RUNNER_TEMP/pr-$PR_NUMBER-event.json"
-          gh api "repos/$REPO/pulls/$PR_NUMBER" | jq '{pull_request: .}' > "$path"
+          jq '{pull_request: .}' "$RESOURCE" > "$path"
           echo "path=$path" >> "$GITHUB_OUTPUT"
 
       - name: Fetch Dependabot metadata

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -305,8 +305,17 @@ jobs:
         run: |
           set -euo pipefail
           for _ in $(seq 1 24); do
+            # `select(. != null)` after `first`, not just `first` alone:
+            # `first` on an empty array (no "Pin Only" status published yet)
+            # is `null`, and `null | {state, description}` is
+            # `{"state": null, "description": null}`, not nothing. Without
+            # the select, that non-empty JSON made `[ -n "$result" ]` true on
+            # the very first poll, read `state` as the literal string "null",
+            # which is not "pending", and exited failed before ever looping.
+            # The select drops the null case so `gh api --jq` emits no output
+            # at all, `result` stays empty, and the loop actually waits.
             result=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
-              --jq '[.statuses[] | select(.context == "Pin Only")] | first | {state, description} | @json' \
+              --jq '[.statuses[] | select(.context == "Pin Only")] | first | select(. != null) | {state, description} | @json' \
               || echo "")
             if [ -n "$result" ]; then
               state=$(printf '%s' "$result" | jq -r '.state')
@@ -327,39 +336,37 @@ jobs:
         # `pull_request` key" when it is absent, confirmed by reading its
         # source (dist/index.js): getMessage, getBranchNames, getBody and
         # getTitle all destructure context.payload.pull_request with no other
-        # fallback. workflow_dispatch carries no such key. The REST pull
-        # request resource the `pr` step above already saved has the same
-        # shape as the webhook payload the action expects, which is what
-        # makes wrapping it in {"pull_request": ...} and pointing
-        # GITHUB_EVENT_PATH at it for the next step a substitution the action
-        # cannot tell apart from the real thing. Built from that saved file
-        # rather than a second API call, so this can never read a pull
-        # request one push newer than what the `pr` step already committed to
-        # for every other output in this job.
+        # fallback. workflow_dispatch's own event carries no such key.
+        #
+        # Pointing GITHUB_EVENT_PATH itself at a different file does not
+        # work: GitHub documents that a step's `env:` cannot override any
+        # `GITHUB_*` or `RUNNER_*` default variable and silently ignores the
+        # attempt, confirmed against GitHub's own documentation. What is
+        # writable is the file that variable already names: an ordinary temp
+        # file on the runner's own disk, not a protected one, and nothing
+        # else in this job reads github.event after this step, so
+        # overwriting its contents here is contained to exactly the one
+        # action that needs it.
+        #
+        # The REST pull request resource the `pr` step above already saved
+        # has the same shape as the webhook payload the action expects,
+        # which is what makes {"pull_request": ...} a substitution the
+        # action cannot tell apart from the real thing. Built from that
+        # saved file rather than a second API call, so this can never read a
+        # pull request one push newer than what the `pr` step already
+        # committed to for every other output in this job.
         if: github.event_name == 'workflow_dispatch' && steps.pr.outputs.author == 'dependabot[bot]'
-        id: synth_event
         env:
           RESOURCE: ${{ steps.pr.outputs.resource }}
-          PR_NUMBER: ${{ matrix.entry.pr_number }}
         shell: bash
         run: |
           set -euo pipefail
-          path="$RUNNER_TEMP/pr-$PR_NUMBER-event.json"
-          jq '{pull_request: .}' "$RESOURCE" > "$path"
-          echo "path=$path" >> "$GITHUB_OUTPUT"
+          jq '{pull_request: .}' "$RESOURCE" > "$GITHUB_EVENT_PATH"
 
       - name: Fetch Dependabot metadata
         id: metadata
         if: steps.pr.outputs.author == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        env:
-          # The real event payload on pull_request_target; the synthetic one
-          # from the step above on workflow_dispatch, which carries no
-          # pull_request key of its own. github.event_path, not a bare
-          # $GITHUB_EVENT_PATH default: this workflow never sets that variable
-          # itself, so there is no runner default to fall back on other than
-          # the one GitHub already exposes through this context.
-          GITHUB_EVENT_PATH: ${{ github.event_name == 'workflow_dispatch' && steps.synth_event.outputs.path || github.event_path }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -385,29 +392,39 @@ jobs:
         # requirements included: they only reach the test virtualenv, and the
         # suite is what clears them either way.
         #
-        # `update-type` is blank for a grouped update (#94, "bump the
-        # test-dependencies group ... with 2 updates"): confirmed live from
-        # that pull request's own run, fetch-metadata has no single semver
-        # level to report for more than one dependency, and this
+        # Graded from `updated-dependencies-json` alone, never from the
+        # top-level `update-type` output. update-type is fetch-metadata's own
+        # summary of the *highest* semver level *present* among a group's
+        # entries, not a guarantee that *every* entry is at or below that
+        # level: `maxSemver` builds a set of each entry's updateType and
+        # returns the first of major/minor/patch found in it, blank entries
+        # included in the set but never selected over a real one. A group
+        # pairing one resolved minor bump with one blank, unresolved entry
+        # therefore reports the top-level type as "version-update:semver-minor",
+        # confirmed by running fetch-metadata's own algorithm against that
+        # exact shape, which would have approved the whole group on the
+        # strength of the one entry that happened to resolve. Reading
+        # `updated-dependencies-json` unconditionally instead, and requiring
+        # every single entry in it to be a patch or minor bump, closes that
+        # gap without opening a new one: for a genuine single-dependency
+        # update this is the same check the top-level field would have made,
+        # since its one entry is exactly what `update-type` was built from.
+        #
+        # A grouped update is the normal shape here, not an edge case: this
         # organization's every repository groups its pre-commit and
-        # github-actions ecosystems with `patterns: ["*"]`, so a grouped bump
-        # is the normal shape, not an edge case, and the patch-or-minor branch
-        # below had been permanently unreachable for Dependabot.
-        # `updated-dependencies-json` is the fallback fetch-metadata itself
-        # documents for exactly this: one entry per dependency, each carrying
-        # its own updateType, so the group is approved only when every single
-        # entry is itself a patch or minor bump; a group hiding even one major
-        # still waits for review. #94 stays unapproved even with this fix in
-        # place: it is a pip "permit the latest version" style update whose
-        # commit message states no prior version for either dependency, so
-        # fetch-metadata cannot compute an update type for either entry at all
-        # (each reports "" confirmed live), and the fallback below correctly
-        # reads that as unresolved rather than as a bump it can vouch for.
+        # github-actions ecosystems with `patterns: ["*"]`, and #94 ("bump
+        # the test-dependencies group ... with 2 updates") is a live example,
+        # confirmed from that pull request's own run. #94 stays unapproved
+        # even with this fix in place: it is a pip "permit the latest
+        # version" style update whose commit message states no prior version
+        # for either dependency, so fetch-metadata cannot compute an update
+        # type for either entry at all (each reports "" confirmed live), and
+        # the check below correctly reads that as unresolved rather than as
+        # a bump it can vouch for.
         id: decide
         env:
           PR_AUTHOR: ${{ steps.pr.outputs.author }}
           HAS_AUTOMERGE_LABEL: ${{ steps.pr.outputs.has_automerge_label }}
-          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
           UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
         run: |
           approve=false
@@ -422,50 +439,37 @@ jobs:
               fi
               ;;
             "dependabot[bot]")
-              case "$UPDATE_TYPE" in
-                version-update:semver-patch | version-update:semver-minor)
-                  approve=true
-                  # Dependabot cannot arm auto-merge itself, unlike Renovate.
-                  arm=true
-                  ;;
-                "")
-                  # A grouped update: fall back to updated-dependencies-json
-                  # and require every dependency in it to be a patch or minor
-                  # bump on its own. Piped in on stdin rather than
-                  # interpolated into the jq program text, so nothing about a
-                  # dependency's name or version is ever read as jq syntax.
-                  #
-                  # shellcheck disable=SC2016
-                  result=$(printf '%s' "$UPDATED_DEPENDENCIES_JSON" | jq -r '
-                      def ok: . == "version-update:semver-patch" or . == "version-update:semver-minor";
-                      if (type != "array") or length == 0 then
-                        "false\tno updated-dependencies-json to fall back on"
-                      else
-                        ([.[].updateType | if . == "" or . == null then "unknown" else . end]) as $types
-                        | if ($types | all(ok)) then
-                            "true\tevery dependency in the group is a patch or minor bump (\($types | join(", ")))"
-                          else
-                            "false\tnot every dependency in the group is a patch or minor bump (\($types | join(", ")))"
-                          end
-                      end
-                    ' 2>/dev/null || echo "")
-                  if [ -z "$result" ]; then
-                    result="false"$'\t'"updated-dependencies-json was empty or could not be parsed as JSON"
-                  fi
-                  IFS=$'\t' read -r group_ok group_reason <<< "$result"
-                  if [ "$group_ok" = "true" ]; then
-                    approve=true
-                    # Dependabot cannot arm auto-merge itself, unlike Renovate.
-                    arm=true
-                    echo "::notice::Update type is blank (a grouped update); $group_reason."
+              # Every entry has to be a patch or minor bump on its own, one
+              # dependency or many. Piped in on stdin rather than
+              # interpolated into the jq program text, so nothing about a
+              # dependency's name or version is ever read as jq syntax.
+              #
+              # shellcheck disable=SC2016
+              result=$(printf '%s' "$UPDATED_DEPENDENCIES_JSON" | jq -r '
+                  def ok: . == "version-update:semver-patch" or . == "version-update:semver-minor";
+                  if (type != "array") or length == 0 then
+                    "false\tno updated-dependencies-json to grade"
                   else
-                    echo "::notice::Update type is blank (a grouped update), and $group_reason, so it waits for review."
-                  fi
-                  ;;
-                *)
-                  echo "::notice::Update type ${UPDATE_TYPE:-unknown} is not a patch or minor bump, so it waits for review."
-                  ;;
-              esac
+                    ([.[].updateType | if . == "" or . == null then "unknown" else . end]) as $types
+                    | if ($types | all(ok)) then
+                        "true\tevery dependency is a patch or minor bump (\($types | join(", ")))"
+                      else
+                        "false\tnot every dependency is a patch or minor bump (\($types | join(", ")))"
+                      end
+                  end
+                ' 2>/dev/null || echo "")
+              if [ -z "$result" ]; then
+                result="false"$'\t'"updated-dependencies-json was empty or could not be parsed as JSON"
+              fi
+              IFS=$'\t' read -r bump_ok bump_reason <<< "$result"
+              if [ "$bump_ok" = "true" ]; then
+                approve=true
+                # Dependabot cannot arm auto-merge itself, unlike Renovate.
+                arm=true
+                echo "::notice::$bump_reason."
+              else
+                echo "::notice::$bump_reason, so it waits for review."
+              fi
               ;;
           esac
 

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -154,25 +154,36 @@ jobs:
               ;;
 
             workflow_dispatch)
+              # The REST list endpoint throughout, not `gh pr list`: its
+              # GraphQL-backed --json author reports a bot's login as
+              # "app/dependabot", not the "dependabot[bot]" shape every other
+              # author check in this file compares against, confirmed live
+              # against this repository's own open pull requests. REST's
+              # `.user.login` matches what github.event.pull_request.user.login
+              # reports on the pull_request_target path above, so every trigger
+              # agrees on what a bot's login looks like.
               if [ -n "$INPUT_PR_NUMBER" ]; then
                 # Digits only, checked before this ever reaches an API path
                 # below: unlike github.event.pull_request.number, which
-                # GitHub has already parsed for us, a workflow_dispatch input
-                # is free text a maintainer types by hand.
+                # GitHub has already parsed for us, this is free text a
+                # maintainer types by hand.
                 if ! [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
                   echo "::error::pr_number must be digits only, got '$INPUT_PR_NUMBER'."
                   exit 1
                 fi
-                matrix=$(jq -nc --arg n "$INPUT_PR_NUMBER" '[{pr_number: ($n | tonumber)}]')
+                # Checked against the same author/fork conditions as the
+                # "check every open one" branch below, rather than trusted on
+                # the strength of workflow_dispatch alone: dispatching this
+                # workflow already takes write access, but a maintainer typing
+                # the wrong number by hand should get a clear, empty matrix
+                # here rather than a same shape mismatch quietly falling
+                # through the decide step's own author check further down.
+                matrix=$(gh api "repos/$REPO/pulls/$INPUT_PR_NUMBER" \
+                  --jq 'if (.user.login == "renovate[bot]" or .user.login == "dependabot[bot]")
+                            and .head.repo.fork == false
+                        then [{pr_number: .number}]
+                        else [] end')
               else
-                # The REST list endpoint, not `gh pr list`: its GraphQL-backed
-                # --json author reports a bot's login as "app/dependabot", not
-                # the "dependabot[bot]" shape every other author check in this
-                # file compares against, confirmed live against this
-                # repository's own open pull requests. REST's `.user.login`
-                # matches what github.event.pull_request.user.login reports on
-                # the pull_request_target path above, so both triggers agree
-                # on what a bot's login looks like.
                 matrix=$(gh api "repos/$REPO/pulls?state=open&per_page=100" \
                   --jq '[.[] | select((.user.login == "renovate[bot]" or .user.login == "dependabot[bot]")
                                   and .head.repo.fork == false)

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -60,33 +60,33 @@ on:
   workflow_run:
     workflows: ["CodeRabbit Gate"]
     types: [completed]
-  # The recovery lever, for the `resolve-bot`/`approve` jobs below only.
-  # Neither `pull_request_target` above fires again once a pull request stops
-  # changing, so a bot pull request that was already open when this file's own
-  # decision changed has no future event left to earn an approval from. #94
-  # and #136 were both stranded exactly that way; #136 was only recovered by
-  # closing and reopening it, which is a clumsy lever to ask of a maintainer.
+  # The recovery lever, for the `nudge-bot` job below only. Neither
+  # `pull_request_target` above fires again once a pull request stops
+  # changing, so a bot pull request that was already open when this file's
+  # own decision changed has no future event left to earn an approval from.
+  # #94 and #136 were both stranded exactly that way; #136 was only
+  # recovered by closing and reopening it, which is a clumsy lever to ask of
+  # a maintainer.
   #
   # `pr_number` follows pull-request-validation.yml's own workflow_dispatch
   # shape: optional, so leaving it blank re-checks every open Dependabot or
   # Renovate pull request instead of one. It is validated as digits-only in
-  # `resolve-bot` below before it ever reaches an API path, since this is free
+  # `nudge-bot` below before it ever reaches an API path, since this is free
   # text a maintainer types by hand, unlike github.event.pull_request.number,
   # which GitHub has already parsed for us.
   #checkov:skip=CKV_GHA_7:workflow_dispatch itself requires write access to
   # trigger at all (GitHub platform-level gate, not something this file
   # controls); pr_number never selects a checkout ref or anything else that
-  # runs, unlike pull-request-validation.yml's own input, since the checkout
-  # below always resolves to the default branch. It only ever selects which
-  # pull request a read-only `gh api` lookup and, if the decision below
-  # approves, `gh pr review`/`gh pr merge --auto` act on, matched against
-  # digits before either happens.
+  # runs. It only ever selects which pull request `nudge-bot` reads and, once
+  # matched against digits and graded eligible, briefly labels through the
+  # API, which is exactly the trust a maintainer typing an issue number into
+  # `/run-check` already carries elsewhere in this organization.
   workflow_dispatch:
     inputs:
       pr_number:
         description: >-
-          Pull request number to re-run the approval decision for. Leave
-          blank to check every open Dependabot or Renovate pull request.
+          Pull request number to re-check. Leave blank to re-check every
+          open Dependabot or Renovate pull request.
         required: false
 
 # The floor. Each job widens it for itself.
@@ -94,143 +94,40 @@ permissions:
   contents: read
 
 jobs:
-  resolve-bot:
-    name: Find the bot pull request(s) to check
-    # Not `workflow_run`: that trigger exists for `resolve-owner`/
-    # `approve-owner` below only, and this job's case statement has no branch
-    # for it. Excluded here rather than given a no-op branch, so an
-    # unhandled-event failure below stays meaningful if this file ever grows
-    # another trigger nobody taught this job about.
-    if: github.event_name != 'workflow_run'
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    permissions:
-      pull-requests: read
-    outputs:
-      # A JSON array of {pr_number}, the same shape resolve-owner below
-      # already outputs and for the same reason: the approve job re-reads
-      # each pull request fresh from the number, so nothing else is worth
-      # carrying through the matrix.
-      matrix: ${{ steps.build.outputs.matrix }}
-    steps:
-      - name: Build the list of bot pull requests to check
-        id: build
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
-          EVENT_ACTION: ${{ github.event.action }}
-          LABEL_NAME: ${{ github.event.label.name }}
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          case "$EVENT_NAME" in
-            pull_request_target)
-              # Read straight off the immutable payload: cheap, and this is
-              # the same trust boundary this job's own predecessor already
-              # relied on. user.login is set by GitHub from the authenticated
-              # author, so a pull request cannot claim to be a bot. Exact
-              # equality, not startsWith or contains: `renovate[bot]-x` is a
-              # login somebody may register, and the non-fork condition is the
-              # second half of the same fence, since reaching this any other
-              # way would take write access to this repository.
-              #
-              # The label condition is about noise rather than correctness.
-              # `labeled` fires once per label, Renovate applies three, and
-              # with `opened` as well #61 collected seven identical approvals
-              # before anything had even run. Only the label actually read
-              # below is worth waking this for.
-              if [ "$IS_FORK" = "false" ] \
-                && { [ "$PR_AUTHOR" = "renovate[bot]" ] || [ "$PR_AUTHOR" = "dependabot[bot]" ]; } \
-                && { [ "$EVENT_ACTION" != "labeled" ] || [ "$LABEL_NAME" = "automerge" ]; }; then
-                matrix=$(jq -nc --arg n "$PR_NUMBER" '[{pr_number: ($n | tonumber)}]')
-              else
-                matrix='[]'
-              fi
-              ;;
-
-            workflow_dispatch)
-              # The REST list endpoint throughout, not `gh pr list`: its
-              # GraphQL-backed --json author reports a bot's login as
-              # "app/dependabot", not the "dependabot[bot]" shape every other
-              # author check in this file compares against, confirmed live
-              # against this repository's own open pull requests. REST's
-              # `.user.login` matches what github.event.pull_request.user.login
-              # reports on the pull_request_target path above, so every trigger
-              # agrees on what a bot's login looks like.
-              if [ -n "$INPUT_PR_NUMBER" ]; then
-                # Digits only, checked before this ever reaches an API path
-                # below: unlike github.event.pull_request.number, which
-                # GitHub has already parsed for us, this is free text a
-                # maintainer types by hand.
-                if ! [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
-                  echo "::error::pr_number must be digits only, got '$INPUT_PR_NUMBER'."
-                  exit 1
-                fi
-                # Checked against the same author/fork conditions as the
-                # "check every open one" branch below, rather than trusted on
-                # the strength of workflow_dispatch alone: dispatching this
-                # workflow already takes write access, but a maintainer typing
-                # the wrong number by hand should get a clear, empty matrix
-                # here rather than a same shape mismatch quietly falling
-                # through the decide step's own author check further down.
-                matrix=$(gh api "repos/$REPO/pulls/$INPUT_PR_NUMBER" \
-                  --jq 'if (.user.login == "renovate[bot]" or .user.login == "dependabot[bot]")
-                            and .head.repo.fork == false
-                        then [{pr_number: .number}]
-                        else [] end')
-              else
-                matrix=$(gh api "repos/$REPO/pulls?state=open&per_page=100" \
-                  --jq '[.[] | select((.user.login == "renovate[bot]" or .user.login == "dependabot[bot]")
-                                  and .head.repo.fork == false)
-                          | {pr_number: .number}]')
-              fi
-              ;;
-
-            *)
-              echo "::error::Unhandled event: $EVENT_NAME"
-              exit 1
-              ;;
-          esac
-
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-          echo "Checking: $matrix"
-
   approve:
     name: Approve and enable auto-merge
-    needs: resolve-bot
-    # An empty array is not an error: nothing resolved to check, and nothing
-    # to approve. `fromJson('[]')` still starts a matrix with zero jobs, which
-    # reports as success on its own with no step of this job ever running,
-    # the same reasoning approve-owner below already relies on.
+    # user.login is set by GitHub from the authenticated author, so a pull
+    # request cannot claim to be a bot. Exact equality, not startsWith or
+    # contains: `renovate[bot]-x` is a login somebody may register, and the
+    # non-fork condition is the second half of the same fence, since reaching
+    # this job any other way would take write access to this repository.
     #
-    # `resolve-bot.result == 'success'` matters as much as the matrix check:
-    # resolve-bot is deliberately skipped on `workflow_run` above, and a
-    # custom `if:` here opts this job out of GitHub's own implicit
-    # "needs succeeded" gate, so a skipped predecessor is not screened out on
-    # its own. Without this, `needs.resolve-bot.outputs.matrix` reads as
-    # empty rather than `'[]'` for a skipped run, `!= '[]'` is still true, and
-    # `fromJson('')` below would fail the job outright on every `workflow_run`
-    # trigger.
-    if: needs.resolve-bot.result == 'success' && needs.resolve-bot.outputs.matrix != '[]'
+    # The label condition is about noise rather than correctness. `labeled`
+    # fires once per label, Renovate applies three, and with `opened` as well
+    # #61 collected seven identical approvals before anything had even run. Only
+    # a label this job actually reads is worth waking it for: `automerge`,
+    # Renovate's own signal, or `bot-recheck`, which the `nudge-bot` job below
+    # applies and removes right back off to manufacture exactly this event
+    # for a pull request stuck with no future trigger of its own, rather than
+    # asking a maintainer to close and reopen it.
+    if: >-
+      github.event.pull_request.head.repo.fork == false && (
+        github.event.pull_request.user.login == 'renovate[bot]' ||
+        github.event.pull_request.user.login == 'dependabot[bot]'
+      ) && (
+        github.event.action != 'labeled' ||
+        github.event.label.name == 'automerge' ||
+        github.event.label.name == 'bot-recheck'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      fail-fast: false
-      matrix:
-        entry: ${{ fromJson(needs.resolve-bot.outputs.matrix) }}
-    # One at a time per pull request. The guard in the Approve step below
-    # reads the reviews and then writes one, so two runs racing between those
-    # two steps would both see no approval and both add one, which is the
-    # pile-up this is meant to end. Queued rather than cancelled: a
-    # superseded run here has nothing to redo, but a cancelled one might have
-    # been the only run that would have approved.
+    # One at a time per pull request. The guard below reads the reviews and then
+    # writes one, so two runs racing between those two steps would both see no
+    # approval and both add one, which is the pile-up this is meant to end.
+    # Queued rather than cancelled: a superseded run here has nothing to redo,
+    # but a cancelled one might have been the only run that would have approved.
     concurrency:
-      group: bot-auto-merge-${{ matrix.entry.pr_number }}
+      group: bot-auto-merge-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
       # For `gh pr merge --auto` on the Dependabot path only. Arming auto-merge
@@ -240,47 +137,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out the default branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@v7
         with:
-          # The repository's default branch, not
-          # github.event.pull_request.base.ref: that context is absent on
-          # workflow_dispatch, and every trigger this job runs under targets
-          # `main` as the base anyway (see the pull_request_target filter
-          # above), so this is not a behavior change on that path.
-          ref: ${{ github.event.repository.default_branch }}
+          # Explicitly the base branch, which is also what pull_request_target
+          # checks out by default. Stated anyway, because the assertion below is
+          # only worth running if it is this repository's copy of it and not the
+          # pull request's, and a default is a poor place to keep that.
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
-
-      - name: Read the pull request's metadata
-        # Stands in for github.event.pull_request.* everywhere below, since
-        # that context only exists on the pull_request_target path;
-        # workflow_dispatch carries nothing but the number resolve-bot put in
-        # the matrix. Read fresh from the API on every trigger rather than
-        # branching per event, the same choice coderabbit-gate.yml's grade job
-        # makes for the same reason: one source of truth for what this pull
-        # request currently looks like, not two that can disagree.
-        #
-        # Written to a file, not just piped into this step's own jq: the
-        # Synthesize step below needs the identical resource, and reading it
-        # from the API a second time there would reopen the same
-        # "not two that can disagree" problem this step exists to close, one
-        # step later.
-        id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ matrix.entry.pr_number }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          resource="$RUNNER_TEMP/pr-$PR_NUMBER.json"
-          gh api "repos/$REPO/pulls/$PR_NUMBER" > "$resource"
-          jq -r '
-            "author=" + .user.login,
-            "html_url=" + .html_url,
-            "head_sha=" + .head.sha,
-            "has_automerge_label=" + ([.labels[].name] | any(. == "automerge") | tostring)
-          ' "$resource" >> "$GITHUB_OUTPUT"
-          echo "resource=$resource" >> "$GITHUB_OUTPUT"
 
       - name: Wait for the published pin-only verdict
         # The check that keeps "approve on the strength of the author" from
@@ -300,7 +164,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -312,8 +176,6 @@ jobs:
             # the select, that non-empty JSON made `[ -n "$result" ]` true on
             # the very first poll, read `state` as the literal string "null",
             # which is not "pending", and exited failed before ever looping.
-            # The select drops the null case so `gh api --jq` emits no output
-            # at all, `result` stays empty, and the loop actually waits.
             result=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
               --jq '[.statuses[] | select(.context == "Pin Only")] | first | select(. != null) | {state, description} | @json' \
               || echo "")
@@ -330,55 +192,9 @@ jobs:
           echo "::error::No settled Pin Only verdict for $HEAD_SHA after two minutes."
           exit 1
 
-      - name: Synthesize a pull_request event payload
-        # dependabot/fetch-metadata reads github.event.pull_request straight
-        # off the event payload file and throws "Event payload missing
-        # `pull_request` key" when it is absent, confirmed by reading its
-        # source (dist/index.js): getMessage, getBranchNames, getBody and
-        # getTitle all destructure context.payload.pull_request with no other
-        # fallback. workflow_dispatch's own event carries no such key.
-        #
-        # Pointing GITHUB_EVENT_PATH itself at a different file does not
-        # work: GitHub documents that a step's `env:` cannot override any
-        # `GITHUB_*` or `RUNNER_*` default variable and silently ignores the
-        # attempt, confirmed against GitHub's own documentation. What is
-        # writable is the file that variable already names: an ordinary temp
-        # file on the runner's own disk, not a protected one, and nothing
-        # else in this job reads github.event after this step, so
-        # overwriting its contents here is contained to exactly the one
-        # action that needs it.
-        #
-        # The REST pull request resource the `pr` step above already saved
-        # has the same shape as the webhook payload the action expects,
-        # which is what makes {"pull_request": ...} a substitution the
-        # action cannot tell apart from the real thing. Built from that
-        # saved file rather than a second API call, so this can never read a
-        # pull request one push newer than what the `pr` step already
-        # committed to for every other output in this job.
-        if: github.event_name == 'workflow_dispatch' && steps.pr.outputs.author == 'dependabot[bot]'
-        env:
-          RESOURCE: ${{ steps.pr.outputs.resource }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          jq '{pull_request: .}' "$RESOURCE" > "$GITHUB_EVENT_PATH"
-          echo "DEBUG event_path=$GITHUB_EVENT_PATH"
-          echo "DEBUG contents:"
-          cat "$GITHUB_EVENT_PATH"
-          echo "DEBUG ls -la:"
-          ls -la "$GITHUB_EVENT_PATH"
-
-      - name: DEBUG recheck event path in a fresh step
-        if: steps.pr.outputs.author == 'dependabot[bot]'
-        shell: bash
-        run: |
-          echo "DEBUG2 event_path=$GITHUB_EVENT_PATH"
-          echo "DEBUG2 contents:"
-          cat "$GITHUB_EVENT_PATH"
-
       - name: Fetch Dependabot metadata
         id: metadata
-        if: steps.pr.outputs.author == 'dependabot[bot]'
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -427,17 +243,19 @@ jobs:
         # organization's every repository groups its pre-commit and
         # github-actions ecosystems with `patterns: ["*"]`, and #94 ("bump
         # the test-dependencies group ... with 2 updates") is a live example,
-        # confirmed from that pull request's own run. #94 stays unapproved
-        # even with this fix in place: it is a pip "permit the latest
-        # version" style update whose commit message states no prior version
-        # for either dependency, so fetch-metadata cannot compute an update
-        # type for either entry at all (each reports "" confirmed live), and
-        # the check below correctly reads that as unresolved rather than as
-        # a bump it can vouch for.
+        # confirmed from that pull request's own run: update-type there is
+        # blank, since fetch-metadata has no single semver level to report
+        # for more than one dependency. #94 stays unapproved even with this
+        # fix in place: it is a pip "permit the latest version" style update
+        # whose commit message states no prior version for either
+        # dependency, so fetch-metadata cannot compute an update type for
+        # either entry at all (each reports "" confirmed live), and the
+        # check below correctly reads that as unresolved rather than as a
+        # bump it can vouch for.
         id: decide
         env:
-          PR_AUTHOR: ${{ steps.pr.outputs.author }}
-          HAS_AUTOMERGE_LABEL: ${{ steps.pr.outputs.has_automerge_label }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HAS_AUTOMERGE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'automerge') }}
           UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
         run: |
           approve=false
@@ -493,8 +311,8 @@ jobs:
         if: steps.decide.outputs.approve == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ steps.pr.outputs.html_url }}
-          PR_NUMBER: ${{ matrix.entry.pr_number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         # Re-approved on every push, which is required rather than wasteful:
         # branch protection dismisses stale reviews, so a rebase drops the
@@ -527,16 +345,16 @@ jobs:
         if: steps.decide.outputs.arm == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ steps.pr.outputs.html_url }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
 
   resolve-owner:
     name: Find the owner's pull request to approve
-    # Not `workflow_dispatch`: that trigger exists for the bot path above
-    # only, and this job's case statement below has no branch for it. The
-    # recovery lever is for a stranded bot pull request; the owner's own
-    # already has `workflow_run` re-running this on every CodeRabbit Gate
-    # completion, so there is nothing here for a manual dispatch to recover.
+    # Not `workflow_dispatch`: that trigger exists for the `nudge-bot` job
+    # below only, and this job's case statement has no branch for it. The
+    # owner's own pull request already has `workflow_run` re-running this on
+    # every CodeRabbit Gate completion, so there is nothing here for a manual
+    # dispatch of the bot recovery lever to do.
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 3
@@ -775,3 +593,110 @@ jobs:
         # step the owner explicitly wants to keep for their own work, even
         # though nothing here would stop the owner running `gh pr merge
         # --auto` by hand if they wanted the same convenience Renovate gets.
+
+  nudge-bot:
+    name: Nudge a stranded bot pull request into a fresh check
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      # For the label add/remove below, which is what actually does the
+      # work: see the step for why a label toggle rather than reading
+      # github.event.pull_request.* directly here.
+      pull-requests: write
+    steps:
+      - name: Find and nudge the target pull request(s)
+        # This job never re-implements the `approve` job's own decision:
+        # doing that here would mean either reading github.event.pull_request,
+        # which does not exist on workflow_dispatch, or re-fetching every
+        # field that job reads from the API and hoping the two copies never
+        # drift, which is the exact failure this file's own "one decision,
+        # one place" convention exists to prevent (see the Decide step's own
+        # comment above for the last time a duplicated copy of this
+        # condition actually did drift).
+        #
+        # A synthetic pull_request event was tried and does not work.
+        # dependabot/fetch-metadata reads context.payload.pull_request from
+        # the file at GITHUB_EVENT_PATH, and neither writable surface holds
+        # still long enough to fake it: a step's `env:` cannot override
+        # GITHUB_EVENT_PATH itself (GitHub documents that a `GITHUB_*` or
+        # `RUNNER_*` variable assignment through `env:` is silently ignored),
+        # and overwriting the file that variable already names does not
+        # survive either, confirmed live: the runner resets it before the
+        # next step starts, so a subsequent step reads the original
+        # workflow_dispatch payload again, not what an earlier step wrote.
+        #
+        # What is left, and what this step does instead, is asking GitHub to
+        # generate a real `labeled` pull_request_target event: adding a
+        # label and then removing it right back off. That event carries an
+        # authentic, complete pull_request payload, exactly what the
+        # `approve` job already reads on every other trigger, so the
+        # approval decision runs through the one path this file has always
+        # had for it. `bot-recheck` is dedicated to this alone, never read
+        # for anything else, so toggling it can never be misread as
+        # Renovate's own `automerge` signal or leave that label's real state
+        # disturbed for a pull request that already carries it.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "$INPUT_PR_NUMBER" ]; then
+            # Digits only, checked before this ever reaches an API path
+            # below: unlike github.event.pull_request.number, which GitHub
+            # has already parsed for us, this is free text a maintainer
+            # types by hand.
+            if ! [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr_number must be digits only, got '$INPUT_PR_NUMBER'."
+              exit 1
+            fi
+            # Checked against the same author, fork and state conditions the
+            # "check every open one" branch below already applies, rather
+            # than trusted on the strength of workflow_dispatch alone:
+            # dispatching this workflow already takes write access, but a
+            # maintainer typing the wrong number by hand should get a clear
+            # "nothing eligible" here rather than a label toggle that fires
+            # an event the `approve` job's own author check then silently
+            # ignores.
+            numbers=$(gh api "repos/$REPO/pulls/$INPUT_PR_NUMBER" \
+              --jq 'if .state == "open"
+                        and (.user.login == "renovate[bot]" or .user.login == "dependabot[bot]")
+                        and .head.repo.fork == false
+                    then .number else empty end')
+          else
+            # The REST list endpoint, not `gh pr list`: its GraphQL-backed
+            # --json author reports a bot's login as "app/dependabot", not
+            # the "dependabot[bot]" shape every other author check in this
+            # file compares against, confirmed live against this
+            # repository's own open pull requests. REST's `.user.login`
+            # matches what github.event.pull_request.user.login reports on
+            # the pull_request_target path the `approve` job reads, so both
+            # agree on what a bot's login looks like.
+            numbers=$(gh api "repos/$REPO/pulls?state=open&per_page=100" \
+              --jq '[.[] | select((.user.login == "renovate[bot]" or .user.login == "dependabot[bot]")
+                              and .head.repo.fork == false)
+                      | .number] | .[]')
+          fi
+
+          if [ -z "$numbers" ]; then
+            echo "No eligible open bot pull request to nudge."
+            exit 0
+          fi
+
+          while read -r number; do
+            [ -n "$number" ] || continue
+            echo "Nudging #$number..."
+            # POST auto-creates the label if this repository has never used
+            # it before, confirmed live, so there is nothing to provision
+            # ahead of time. DELETE right after: leaving the label on would
+            # make a second recovery attempt against the same pull request a
+            # no-op, since GitHub does not fire `labeled` for a label that is
+            # already there.
+            gh api --method POST "repos/$REPO/issues/$number/labels" \
+              -f "labels[]=bot-recheck" --silent
+            gh api --method DELETE "repos/$REPO/issues/$number/labels/bot-recheck" \
+              --silent
+          done <<< "$numbers"

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -66,7 +66,9 @@ on:
   # own decision changed has no future event left to earn an approval from.
   # #94 and #136 were both stranded exactly that way; #136 was only
   # recovered by closing and reopening it, which is a clumsy lever to ask of
-  # a maintainer.
+  # a maintainer, and `nudge-bot` below replaces it for Renovate. It cannot
+  # replace it for Dependabot: see that job for why, and what still needs
+  # closing and reopening until that changes.
   #
   # `pr_number` follows pull-request-validation.yml's own workflow_dispatch
   # shape: optional, so leaving it blank re-checks every open Dependabot or
@@ -77,10 +79,10 @@ on:
   #checkov:skip=CKV_GHA_7:workflow_dispatch itself requires write access to
   # trigger at all (GitHub platform-level gate, not something this file
   # controls); pr_number never selects a checkout ref or anything else that
-  # runs. It only ever selects which pull request `nudge-bot` reads and, once
-  # matched against digits and graded eligible, briefly labels through the
-  # API, which is exactly the trust a maintainer typing an issue number into
-  # `/run-check` already carries elsewhere in this organization.
+  # runs. It only ever selects which pull request `nudge-bot` reads and,
+  # once matched against digits and graded eligible, approves through the
+  # API, the same trust a maintainer already has through `gh pr review`
+  # directly.
   workflow_dispatch:
     inputs:
       pr_number:
@@ -105,19 +107,14 @@ jobs:
     # The label condition is about noise rather than correctness. `labeled`
     # fires once per label, Renovate applies three, and with `opened` as well
     # #61 collected seven identical approvals before anything had even run. Only
-    # a label this job actually reads is worth waking it for: `automerge`,
-    # Renovate's own signal, or `bot-recheck`, which the `nudge-bot` job below
-    # applies and removes right back off to manufacture exactly this event
-    # for a pull request stuck with no future trigger of its own, rather than
-    # asking a maintainer to close and reopen it.
+    # the label this job actually reads is worth waking it for.
     if: >-
       github.event.pull_request.head.repo.fork == false && (
         github.event.pull_request.user.login == 'renovate[bot]' ||
         github.event.pull_request.user.login == 'dependabot[bot]'
       ) && (
         github.event.action != 'labeled' ||
-        github.event.label.name == 'automerge' ||
-        github.event.label.name == 'bot-recheck'
+        github.event.label.name == 'automerge'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -595,47 +592,51 @@ jobs:
         # --auto` by hand if they wanted the same convenience Renovate gets.
 
   nudge-bot:
-    name: Nudge a stranded bot pull request into a fresh check
+    name: Re-check a stranded bot pull request
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
-      # For the label add/remove below, which is what actually does the
-      # work: see the step for why a label toggle rather than reading
-      # github.event.pull_request.* directly here.
       pull-requests: write
     steps:
-      - name: Find and nudge the target pull request(s)
-        # This job never re-implements the `approve` job's own decision:
-        # doing that here would mean either reading github.event.pull_request,
-        # which does not exist on workflow_dispatch, or re-fetching every
-        # field that job reads from the API and hoping the two copies never
-        # drift, which is the exact failure this file's own "one decision,
-        # one place" convention exists to prevent (see the Decide step's own
-        # comment above for the last time a duplicated copy of this
-        # condition actually did drift).
+      - name: Find and re-check the target pull request(s)
+        # Two things were tried here first, and neither survives contact
+        # with how GitHub actually runs this.
         #
-        # A synthetic pull_request event was tried and does not work.
-        # dependabot/fetch-metadata reads context.payload.pull_request from
-        # the file at GITHUB_EVENT_PATH, and neither writable surface holds
-        # still long enough to fake it: a step's `env:` cannot override
-        # GITHUB_EVENT_PATH itself (GitHub documents that a `GITHUB_*` or
-        # `RUNNER_*` variable assignment through `env:` is silently ignored),
-        # and overwriting the file that variable already names does not
-        # survive either, confirmed live: the runner resets it before the
-        # next step starts, so a subsequent step reads the original
-        # workflow_dispatch payload again, not what an earlier step wrote.
+        # A synthetic pull_request event for dependabot/fetch-metadata,
+        # which reads context.payload.pull_request straight off the file at
+        # GITHUB_EVENT_PATH and throws "Event payload missing `pull_request`
+        # key" outside a real pull_request or pull_request_target trigger.
+        # Neither writable surface holds still long enough to fake one: a
+        # step's `env:` cannot override GITHUB_EVENT_PATH itself (GitHub
+        # documents that a `GITHUB_*` or `RUNNER_*` variable assignment
+        # through `env:` is silently ignored), and overwriting the file that
+        # variable already names does not survive either, confirmed live:
+        # the runner resets it before the next step starts.
         #
-        # What is left, and what this step does instead, is asking GitHub to
-        # generate a real `labeled` pull_request_target event: adding a
-        # label and then removing it right back off. That event carries an
-        # authentic, complete pull_request payload, exactly what the
-        # `approve` job already reads on every other trigger, so the
-        # approval decision runs through the one path this file has always
-        # had for it. `bot-recheck` is dedicated to this alone, never read
-        # for anything else, so toggling it can never be misread as
-        # Renovate's own `automerge` signal or leave that label's real state
-        # disturbed for a pull request that already carries it.
+        # Manufacturing a real `labeled` pull_request_target event instead,
+        # by adding and removing a label through the API. That data would
+        # have been genuine, but the event never fires: GitHub documents
+        # that it does not start new workflow runs from most events created
+        # using the repository's own GITHUB_TOKEN, `workflow_dispatch` and
+        # `repository_dispatch` being the only exceptions, specifically to
+        # prevent recursive runs. Confirmed live: toggling a label on #94
+        # produced the label history entries and nothing else, no new run.
+        # Only a personal access token or a GitHub App installation token
+        # sidesteps that, and this repository stores neither.
+        #
+        # What is left, and what this step does, is grade a Renovate pull
+        # request directly: unlike Dependabot's, that decision was already
+        # small (has the `automerge` label? not already approved?) and reads
+        # entirely off the API, no marketplace action involved, so
+        # duplicating it here is a bounded, low-risk copy rather than the
+        # kind that drifted before (see the Decide step's own comment in the
+        # `approve` job above). A Dependabot pull request cannot be graded
+        # this way: dependabot/fetch-metadata is the one thing here that
+        # only works on a real trigger, so this reports why and leaves
+        # closing and reopening the pull request, which is a genuine
+        # `reopened` trigger, as the still-clumsy but still-working lever
+        # for that half.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -653,14 +654,6 @@ jobs:
               echo "::error::pr_number must be digits only, got '$INPUT_PR_NUMBER'."
               exit 1
             fi
-            # Checked against the same author, fork and state conditions the
-            # "check every open one" branch below already applies, rather
-            # than trusted on the strength of workflow_dispatch alone:
-            # dispatching this workflow already takes write access, but a
-            # maintainer typing the wrong number by hand should get a clear
-            # "nothing eligible" here rather than a label toggle that fires
-            # an event the `approve` job's own author check then silently
-            # ignores.
             numbers=$(gh api "repos/$REPO/pulls/$INPUT_PR_NUMBER" \
               --jq 'if .state == "open"
                         and (.user.login == "renovate[bot]" or .user.login == "dependabot[bot]")
@@ -682,21 +675,33 @@ jobs:
           fi
 
           if [ -z "$numbers" ]; then
-            echo "No eligible open bot pull request to nudge."
+            echo "No eligible open bot pull request to re-check."
             exit 0
           fi
 
           while read -r number; do
             [ -n "$number" ] || continue
-            echo "Nudging #$number..."
-            # POST auto-creates the label if this repository has never used
-            # it before, confirmed live, so there is nothing to provision
-            # ahead of time. DELETE right after: leaving the label on would
-            # make a second recovery attempt against the same pull request a
-            # no-op, since GitHub does not fire `labeled` for a label that is
-            # already there.
-            gh api --method POST "repos/$REPO/issues/$number/labels" \
-              -f "labels[]=bot-recheck" --silent
-            gh api --method DELETE "repos/$REPO/issues/$number/labels/bot-recheck" \
-              --silent
+            pr=$(gh api "repos/$REPO/pulls/$number")
+            author=$(printf '%s' "$pr" | jq -r '.user.login')
+
+            case "$author" in
+              "renovate[bot]")
+                has_label=$(printf '%s' "$pr" | jq -r '[.labels[].name] | any(. == "automerge")')
+                if [ "$has_label" != "true" ]; then
+                  echo "#$number: no automerge label, so Renovate is not asking for this to merge on its own."
+                  continue
+                fi
+                existing=$(gh api --paginate "repos/$REPO/pulls/$number/reviews" \
+                  | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+                if [ "$existing" -gt 0 ]; then
+                  echo "#$number: already approved and not dismissed. Nothing to do."
+                  continue
+                fi
+                gh pr review --approve "$(printf '%s' "$pr" | jq -r '.html_url')"
+                echo "#$number: approved."
+                ;;
+              "dependabot[bot]")
+                echo "::warning::#$number is a Dependabot pull request. Its grouped-update check needs dependabot/fetch-metadata, which only works on a real pull_request_target event; this job cannot manufacture one that survives GitHub's own recursive-trigger guard. Close and reopen the pull request to re-trigger it for real."
+                ;;
+            esac
           done <<< "$numbers"


### PR DESCRIPTION
## What

Two changes to `bot-auto-merge.yml`.

**1. Approve grouped Dependabot bumps.** `dependabot/fetch-metadata`'s
top-level `update-type` output is blank for a grouped update, since it has
no single semver level to report for more than one dependency. Every
repository in this organization groups its `pre-commit` and `github-actions`
ecosystems with `patterns: ["*"]`, so a grouped bump is the normal shape,
not an edge case, and the patch-or-minor branch had been permanently
unreachable for Dependabot as a result. Verified live on PR #94, run
33580878613: `outputs.update-type: null`.

The decide step now grades `updated-dependencies-json` unconditionally
(never the top-level `update-type`) and approves only when every single
entry in it is a patch or minor bump. This matters for more than the blank
case: `update-type` reports the *highest* level *present*, not a guarantee
every entry is at or below it, so a group pairing one resolved minor bump
with one unresolved entry reports `update-type` as
`version-update:semver-minor` and would have been approved on the strength
of the one entry that resolved. Verified by running fetch-metadata's own
`maxSemver` algorithm against that exact shape.

Also fixes a real bug found in the same area: the `Pin Only` poll read an
absent status as an already-failed one and gave up on the first try instead
of waiting.

**2. A `workflow_dispatch` recovery lever.** `approve` only fires on
`pull_request_target`, so a pull request that was already open when the
approval logic changed never gets a fresh chance at it — #94 and #136 were
both stranded this way, and #136 was only recovered by closing and
reopening it. `workflow_dispatch` now takes an optional `pr_number`
(validated digits-only before it reaches an API path, following
`pull-request-validation.yml`'s own shape), so a maintainer can re-check one
pull request or every open bot pull request when left blank.

This does not work identically for both bot authors, and that split is
deliberate rather than an oversight:

- **Renovate**: fully solved. Its decision is small and reads entirely off
  the API (has the `automerge` label, not already approved), so the new
  `nudge-bot` job duplicates it directly — a bounded, low-risk copy, unlike
  the drift this file suffered once when the same condition was written out
  twice (see the Decide step's own comment).
- **Dependabot**: not solved, and reports why. `dependabot/fetch-metadata`
  only works on a real `pull_request`/`pull_request_target` event; it reads
  `github.event.pull_request` directly off the file at `GITHUB_EVENT_PATH`
  and throws otherwise. Two ways to fake that were tried and both failed
  live:
  - Overriding `GITHUB_EVENT_PATH` through a step's `env:` does nothing:
    GitHub documents that a `GITHUB_*`/`RUNNER_*` variable assignment
    through `env:` is silently ignored.
  - Overwriting the file that variable already names doesn't survive either
    — confirmed live, the runner resets it before the next step starts.
  - A real `labeled` event via an add/remove label toggle was tried next.
    The label history entries were genuine, but no new workflow run ever
    fired: GitHub does not start new runs from most events created with the
    repository's own `GITHUB_TOKEN`, and `labeled` is not one of the two
    documented exceptions (`workflow_dispatch`, `repository_dispatch`).
    Confirmed live against #94.

  `nudge-bot` reports this explicitly for a Dependabot pull request and
  leaves closing and reopening it — a genuine `reopened` trigger — as the
  still-clumsy lever that still works, rather than silently doing nothing
  or approving on unreliable data.

## Left alone

PR #94 stays open and unapproved on purpose: it is a pip "permit the latest
version" style grouped update whose commit message states no prior version
for either dependency, so `fetch-metadata` cannot compute an update type for
either entry at all. The fallback correctly reads that as unresolved rather
than as a bump it can vouch for, and running the new recovery job against it
live confirms this: no approval, no mutation, just the explicit Dependabot
warning above. #97, #103, #136, #137 are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation to approve eligible bot-generated updates more consistently.
  * Added a manually triggered workflow to process eligible Renovate pull requests.
  * Improved handling of dependency update information and empty status results.
  * Dependabot pull requests requiring renewed processing may still need to be closed and reopened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->