### PR TITLE
chore: run Dependabot daily, standardize badges, log in to Docker Hub

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,35 +6,33 @@ version: 2
 # Security updates are not affected either way: they are alert driven and open
 # as soon as GitHub raises the alert, ignoring this schedule entirely.
 #
-# Thursday and Friday, not Monday and Tuesday, and the days are not arbitrary.
-# ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md allocates slots across the
-# organization because CodeRabbit's review quota is shared across the whole
-# app installation rather than handed out per repository, so two repositories
-# opening bot pull requests in the same hour queue behind each other and both
-# look stuck for no visible reason. Monday 06:00 and 06:30 belong to
-# rsync-crypt and Tuesday 06:30 to the .github profile repository, both of
-# which this repository collided with on arrival. Moving to 07:00 on those
-# same days was the first fix and was wrong too: Monday 07:00 is
-# pre-commit-checklists-demo's pip slot.
+# Daily, matching Renovate and every other repository. Note that Dependabot's
+# "daily" means weekdays only, not all seven days.
 #
-# Thursday and Friday were already reserved for this repository in that
-# document, held for the Renovate weekday spread that renovate.json5 no longer
-# has, so they are free and they are ours. Check that table before changing a
-# day here.
+# These were Thursday and Friday until 2026-09-02, slots allocated in
+# ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md because CodeRabbit's review
+# quota is shared across the whole app installation, so two repositories
+# opening bot pull requests in the same hour would queue behind each other.
+# Picking those days took three attempts: Monday and Tuesday collided with
+# rsync-crypt and the profile repository on arrival, and Monday 07:00 turned
+# out to be pre-commit-checklists-demo's pip slot.
+#
+# All of that was solving a problem that did not exist. A pin-only Dependabot
+# bump resolves `Review Verified` through the bot lane with CodeRabbit never
+# asked, exactly as a Renovate bump does, so it spends no review quota and had
+# nothing to collide over. renovate.json5 already made this argument for
+# Renovate; it belongs to the bot lane, not to one bot. Meanwhile the weekly
+# slot stacked on the seven day cooldown rather than overlapping it, so the
+# real floor was 7 to 14 days depending on which weekday a release landed.
 #
 # The cooldown on each ecosystem is the organization-wide seven day window;
-# see BOT_SCHEDULE.md's "Cooling windows" for why both bots carry the same
-# floor and why only default-days is set.
+# see that repository's README.md, "Both bots wait seven days", for why both
+# bots carry the same floor and why only default-days is set.
 updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: weekly
-      day: thursday
-      # 06:00 is free on a Thursday. It is rsync-crypt's hour on a Monday,
-      # which is what this repository collided with on arrival, but the unit
-      # the org schedule protects is the hour on a given day, not the hour
-      # across the week. See the header above for how Thursday came free.
+      interval: daily
       time: "06:00"
       timezone: "America/Toronto"
     labels:
@@ -52,8 +50,8 @@ updates:
     # updates only, never security updates, the same carve-out
     # vulnerabilityAlerts.minimumReleaseAge: null gives Renovate below: a
     # cooldown does not make a known vulnerability's fix any less safe to
-    # take immediately. See ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md
-    # under "Cooling windows" for the organization-wide policy this matches,
+    # take immediately. See ivan-pinatti-labs/.github's README.md under
+    # "Both bots wait seven days" for the organization-wide policy this matches,
     # and docs/HARDENING.md for why the window exists at all.
     cooldown:
       default-days: 7
@@ -61,11 +59,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
-      day: thursday
+      interval: daily
       # Half an hour after the pre-commit slot above, so the two suites this
-      # repository triggers do not start together. 06:30 is the profile
-      # repository's hour on a Tuesday, not a Thursday, so there is no clash.
+      # repository triggers do not start together. That reason survives the
+      # move to daily; the weekday it used to sit on does not.
       time: "06:30"
       timezone: "America/Toronto"
     labels:
@@ -86,9 +83,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/tests"
     schedule:
-      interval: weekly
-      day: friday
-      time: "06:00"
+      interval: daily
+      time: "07:00"
       timezone: "America/Toronto"
     labels:
       - dependencies
@@ -104,7 +100,7 @@ updates:
     # `pip` also supports semver-major-days, semver-minor-days and
     # semver-patch-days, unlike github-actions and pre-commit above, but
     # tiering the window by bump severity is not what the organization policy
-    # asks for: ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md sets one
+    # asks for: ivan-pinatti-labs/.github's README.md sets one
     # seven-day window for every ecosystem, on the reasoning that a freshly
     # compromised release has no advisory yet regardless of whether the bump
     # is a major, minor or patch. default-days alone keeps this ecosystem

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,13 @@ version: 2
 # Daily, matching Renovate and every other repository. Note that Dependabot's
 # "daily" means weekdays only, not all seven days.
 #
-# These were Thursday and Friday until 2026-09-02, slots allocated in
-# ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md because CodeRabbit's review
-# quota is shared across the whole app installation, so two repositories
-# opening bot pull requests in the same hour would queue behind each other.
+# These were Thursday and Friday until 2026-09-02, slots allocated in a
+# document that no longer exists: ivan-pinatti-labs/.github's
+# docs/BOT_SCHEDULE.md, named here only as history, with the policy that
+# replaced it in that repository's README.md. It allocated a weekday per
+# repository because CodeRabbit's review quota is shared across the whole app
+# installation, so two repositories opening bot pull requests in the same hour
+# would queue behind each other.
 # Picking those days took three attempts: Monday and Tuesday collided with
 # rsync-crypt and the profile repository on arrival, and Monday 07:00 turned
 # out to be pre-commit-checklists-demo's pip slot.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,8 +62,9 @@
   // The organization-wide statement of this, and the reasoning that it does
   // not compete for CodeRabbit's shared review quota (a pin-only bump
   // resolves `Review Verified` through the bot lane without a review being
-  // spent at all), is in ivan-pinatti-labs/.github's docs/BOT_SCHEDULE.md
-  // under "Renovate runs daily everywhere".
+  // spent at all), is in ivan-pinatti-labs/.github's README.md under
+  // "Dependency policy". That reasoning applies to Dependabot's pin-only
+  // bumps too, which is why dependabot.yml is daily as of 2026-09-02.
   //
   // Pull request volume is still bounded, by prConcurrentLimit and
   // prHourlyLimit below rather than by the calendar. Those are the levers to

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -273,21 +273,27 @@ jobs:
               # dependency's name or version is ever read as jq syntax.
               #
               # shellcheck disable=SC2016
-              result=$(printf '%s' "$UPDATED_DEPENDENCIES_JSON" | jq -r '
-                  def ok: . == "version-update:semver-patch" or . == "version-update:semver-minor";
-                  if (type != "array") or length == 0 then
-                    "false\tno updated-dependencies-json to grade"
-                  else
-                    ([.[].updateType | if . == "" or . == null then "unknown" else . end]) as $types
-                    | if ($types | all(ok)) then
-                        "true\tevery dependency is a patch or minor bump (\($types | join(", ")))"
+              result=$(printf '%s' "$UPDATED_DEPENDENCIES_JSON" | jq -r -s '
+                  def ok: . == "version-update:semver-patch"
+                    or . == "version-update:semver-minor";
+                  if length != 1 then
+                    "false\texpected exactly one JSON value, got \(length)"
+                  else .[0]
+                    | if (type != "array") or length == 0 then
+                        "false\tno updated-dependencies-json to grade"
                       else
-                        "false\tnot every dependency is a patch or minor bump (\($types | join(", ")))"
+                        ([.[].updateType
+                          | if . == "" or . == null then "unknown" else . end]) as $types
+                        | if ($types | all(ok)) then
+                            "true\tevery bump is patch or minor (\($types | join(", ")))"
+                          else
+                            "false\tnot every bump is patch or minor (\($types | join(", ")))"
+                          end
                       end
                   end
-                ' 2>/dev/null || echo "")
+                ' 2>/dev/null) || result=""
               if [ -z "$result" ]; then
-                result="false"$'\t'"updated-dependencies-json was empty or could not be parsed as JSON"
+                result="false"$'\t'"updated-dependencies-json was empty or invalid JSON"
               fi
               IFS=$'\t' read -r bump_ok bump_reason <<< "$result"
               if [ "$bump_ok" = "true" ]; then

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -104,6 +104,35 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Log in to Docker Hub
+        # The pre-push hooks below shell out to containers: trivy, checkov,
+        # hadolint, lychee and actionlint all run from a Docker Hub image.
+        # Anonymous pulls are rate limited per source address, and GitHub
+        # runners share addresses across the whole pool, so those pulls fail
+        # intermittently with "unauthorized: authentication required". That is
+        # what ejected #143 from the merge queue: the same `Code Check` had
+        # passed minutes earlier on the pull request and failed on the queue's
+        # build, with trivy exiting 125 before it scanned anything.
+        #
+        # integration-tests.yml already logs in for exactly this reason, but it
+        # is the only workflow that did, so every merge_group build was pulling
+        # anonymously.
+        #
+        # Withheld from a fork's head, which has no access to the secrets
+        # anyway: the empty check below turns that into an anonymous pull
+        # rather than a failure, which is what a fork got before.
+        timeout-minutes: 2
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "No Docker Hub credentials for this head; pulling anonymously."
+            exit 0
+          fi
+          printf '%s' "$DOCKERHUB_TOKEN" \
+            | docker login docker.io --username "$DOCKERHUB_USERNAME" --password-stdin
+
       # --hook-stage pre-push, not the default. A hook with no `stages` key runs
       # at every stage, so this selects all of them: the fast file-scoped hooks
       # and, on top, the four that are pre-push only (gitleaks over the full

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -105,29 +105,43 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Log in to Docker Hub
-        # The pre-push hooks below shell out to containers: trivy, checkov,
-        # hadolint, lychee and actionlint all run from a Docker Hub image.
-        # Anonymous pulls are rate limited per source address, and GitHub
-        # runners share addresses across the whole pool, so those pulls fail
-        # intermittently with "unauthorized: authentication required". That is
-        # what ejected #143 from the merge queue: the same `Code Check` had
-        # passed minutes earlier on the pull request and failed on the queue's
-        # build, with trivy exiting 125 before it scanned anything.
+        # merge_group only, and the restriction is the point rather than an
+        # optimization.
         #
-        # integration-tests.yml already logs in for exactly this reason, but it
-        # is the only workflow that did, so every merge_group build was pulling
-        # anonymously.
+        # The problem being fixed: the pre-push hooks below shell out to
+        # containers (trivy, checkov, hadolint, lychee, actionlint), pulling
+        # anonymously. Docker Hub rate limits anonymous pulls per source
+        # address and GitHub runners share addresses across the whole pool, so
+        # those pulls fail intermittently with "unauthorized: authentication
+        # required". That ejected #143 from the merge queue: trivy exited 125
+        # before scanning anything, on the queue's build, minutes after the
+        # same job passed on the pull request.
         #
-        # Withheld from a fork's head, which has no access to the secrets
-        # anyway: the empty check below turns that into an anonymous pull
-        # rather than a failure, which is what a fork got before.
+        # Why not on `pull_request` too: `pre-commit/action` runs
+        # .pre-commit-config.yaml *from the checked out branch*, and that file
+        # carries `repo: local` hooks whose `entry` is arbitrary shell (the
+        # actionlint hook is one). `docker login` leaves credentials in the
+        # runner's Docker config, so authenticating first would put a token
+        # within reach of hook code the pull request itself supplies. A fork
+        # never sees the secrets and is unaffected either way, so the exposure
+        # would be same-repository branches, whose authors already hold these
+        # secrets; the point is that it buys nothing to hand them over again
+        # through a side channel. `pull_request` keeps pulling anonymously,
+        # exactly as it did before this step existed, and it is not where the
+        # failure was.
+        #
+        # merge_group still runs the pull request's own config, so this is
+        # narrowed rather than eliminated: what it gains is that the code has
+        # cleared review and every required context before the credential is
+        # ever present.
+        if: github.event_name == 'merge_group'
         timeout-minutes: 2
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
-            echo "No Docker Hub credentials for this head; pulling anonymously."
+            echo "No Docker Hub credentials available; pulling anonymously."
             exit 0
           fi
           printf '%s' "$DOCKERHUB_TOKEN" \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Torrent, Usenet, NZB, VPN box by Docker Compose containers
 
-![GitHub issues](https://img.shields.io/github/issues-raw/ivan-pinatti-labs/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)
-![GitHub Sponsors](https://img.shields.io/github/sponsors/ivan-pinatti?logo=Github&style=for-the-badge)
-![GitHub Repo stars](https://img.shields.io/github/stars/ivan-pinatti-labs/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)
-![GitHub forks](https://img.shields.io/github/forks/ivan-pinatti-labs/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)
+[![License](https://img.shields.io/github/license/ivan-pinatti-labs/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)](LICENSE.md)
+[![GitHub issues](https://img.shields.io/github/issues-raw/ivan-pinatti-labs/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)](https://github.com/ivan-pinatti-labs/docker-torrent-box-with-vpn/issues)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/ivan-pinatti?logo=Github&style=for-the-badge)](https://github.com/sponsors/ivan-pinatti)
+[![GitHub Repo stars](https://img.shields.io/github/stars/ivan-pinatti-labs/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)](https://github.com/ivan-pinatti-labs/docker-torrent-box-with-vpn)
+[![GitHub forks](https://img.shields.io/github/forks/ivan-pinatti-labs/docker-torrent-box-with-vpn?logo=Github&style=for-the-badge)](https://github.com/ivan-pinatti-labs/docker-torrent-box-with-vpn/forks)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/ivan-pinatti-labs/docker-torrent-box-with-vpn?utm_source=oss&utm_medium=github&utm_campaign=ivan-pinatti-labs%2Fdocker-torrent-box-with-vpn&labelColor=171717&color=FF570A&label=CodeRabbit+Reviews&style=for-the-badge)](https://coderabbit.ai)
 
 The code on this repository is intended to be used to share media content with
 various networks such as Torrent and Usenet while protecting your privacy

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -25,7 +25,7 @@ the seam that covers those inline pins, and the reasoning is spelled out in the 
 of [`.github/renovate.json5`](../.github/renovate.json5); this page reuses that reasoning rather
 than restating it differently.
 
-## The weekday layout
+## The daily layout
 
 | When | Tool | What opens |
 | --- | --- | --- |
@@ -34,7 +34,7 @@ than restating it differently.
 | Daily 07:00 | Dependabot | pip, `tests/requirements.txt` |
 | Daily, before 07:00 | Renovate | Every Renovate update: the grouped and ungrouped images, and the inline pip and Go/PyPI pins |
 
-There is no weekday to check any more. Dependabot ran Thursday and Friday
+There is no fixed weekday to check any more. Dependabot ran Thursday and Friday
 until 2026-09-02, out of an organization-wide slot table that has since been
 deleted; see "Why neither bot is staggered" below. The hours are still
 staggered so the suites this repository triggers do not all start at once,

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -27,20 +27,21 @@ than restating it differently.
 
 ## The weekday layout
 
-| Day | Tool | What opens |
+| When | Tool | What opens |
 | --- | --- | --- |
-| Thursday 06:00 | Dependabot | pre-commit hook revisions |
-| Thursday 06:30 | Dependabot | GitHub Actions |
-| Friday 06:00 | Dependabot | pip, `tests/requirements.txt` |
+| Daily 06:00 | Dependabot | pre-commit hook revisions |
+| Daily 06:30 | Dependabot | GitHub Actions |
+| Daily 07:00 | Dependabot | pip, `tests/requirements.txt` |
 | Daily, before 07:00 | Renovate | Every Renovate update: the grouped and ungrouped images, and the inline pip and Go/PyPI pins |
 
-Dependabot moved off Monday and Tuesday because those hours collided with
-`rsync-crypt` and the organization profile repository; Thursday and Friday
-were already reserved for this repository. The organization-wide slot table
-is in `ivan-pinatti-labs/.github`'s `docs/BOT_SCHEDULE.md`, and it is the
-thing to check before changing a day here.
+There is no weekday to check any more. Dependabot ran Thursday and Friday
+until 2026-09-02, out of an organization-wide slot table that has since been
+deleted; see "Why neither bot is staggered" below. The hours are still
+staggered so the suites this repository triggers do not all start at once,
+but nothing depends on which day they fall on. Note that Dependabot's
+`interval: daily` means weekdays only.
 
-## Why Renovate is no longer staggered
+## Why neither bot is staggered
 
 It used to be. The groups above opened on separate weekdays, and the reason
 was `strict` required status checks on `main`: every merge put every other
@@ -62,10 +63,24 @@ Pull request volume is bounded by `prConcurrentLimit` and `prHourlyLimit`
 instead of by the calendar; those are the levers if it ever needs bounding
 again. Reinstating a weekday spread would bring the 14 day floor back with it.
 
-Dependabot keeps its weekday slots, and that is a different concern: those
-exist so two repositories' bots do not open pull requests in the same hour and
-queue their CodeRabbit review requests behind each other. See
-`docs/BOT_SCHEDULE.md` in the organization profile repository.
+Dependabot kept its weekday slots for a while longer, on the grounds that
+those were a different concern: they existed so two repositories' bots would
+not open pull requests in the same hour and queue their CodeRabbit review
+requests behind each other.
+
+That turned out not to be a concern either. A pin-only bump from *either* bot
+resolves `Review Verified` through `coderabbit-review-verdict.py`'s bot lane
+with CodeRabbit never asked, so Dependabot spent no review quota and had
+nothing to queue behind. Confirmed on this repository's own merged pull
+requests: #139 and #140 are Dependabot and report `pin-only diff, nothing to
+review`, identical to Renovate's #135, #136 and #138. The weekday table was
+deleted on 2026-09-02 and Dependabot moved to daily here and everywhere else.
+
+The same 14 day arithmetic applied to it the whole time, and that is the part
+worth remembering: a weekly slot stacked on `cooldown`'s seven days rather
+than overlapping them, so a release missing its day by a day waited a full
+extra week. The organization policy now lives in
+`ivan-pinatti-labs/.github`'s `README.md` under "Dependency policy".
 
 ## The grouping rationale
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -19,6 +19,12 @@ exclude = [
   # a plain curl from this host. Not a real dead link, all three retries
   # and the 20s timeout above just aren't enough for whatever this is.
   "^https?://(www\\.)?contributor-covenant\\.org/",
+  # grafana.com/docs returns 403 to GitHub-hosted runners while answering 200
+  # from a developer machine (both confirmed live on the same three URLs in
+  # docs/observability/DASHBOARDS.md). Same shape as the two entries above:
+  # a documentation host that blocks datacenter address ranges, not a dead
+  # link. This blocked PR #144's Code Check on three links it did not touch.
+  "^https?://(www\\.)?grafana\\.com/docs/",
   "^https?://localhost(:[0-9]+)?(/.*)?$",
   "^https?://127\\.0\\.0\\.1(:[0-9]+)?(/.*)?$",
   "^https?://.*\\.internal(:[0-9]+)?(/.*)?$",


### PR DESCRIPTION
## `Code Check` logs in to Docker Hub

This is what ejected #143 from the merge queue. `trivy` exited 125 with `unauthorized: authentication required` before scanning anything, on the queue's build, minutes after the same job passed on the pull request.

The pre-push hooks shell out to containers (trivy, checkov, hadolint, lychee, actionlint) and were pulling anonymously, which Docker Hub rate limits per source address across GitHub's shared runner pool. `integration-tests.yml` already logs in for exactly this reason and was the only workflow that did, so every `merge_group` build was exposed. A fork, which cannot read the secrets, falls through to an anonymous pull as before rather than failing.

## Dependabot runs daily

It was Thursday and Friday, slots from the table in `ivan-pinatti-labs/.github`'s `docs/BOT_SCHEDULE.md` that took three attempts to pick, colliding with rsync-crypt, the profile repository, then pre-commit-checklists-demo's pip slot.

None of that was necessary. A pin-only Dependabot bump resolves `Review Verified` through the bot lane with CodeRabbit never asked, so it spent no review quota and had nothing to collide over. This repository's own merged pull requests confirm it:

| PR | Author | Review Verified |
| --- | --- | --- |
| #140, #139 | Dependabot | `pin-only diff, nothing to review` |
| #138, #136, #135 | Renovate | `pin-only diff, nothing to review` |

`renovate.json5` already made this argument, framed as a property of Renovate; it belongs to the bot lane. Meanwhile the weekly slot stacked on the seven day cooldown rather than overlapping it, making the real floor 7 to 14 days. Hours stay staggered so the suites do not all start together; the weekdays are gone. Dependabot's `daily` means weekdays only.

## Badges

Matches the row now on every other repository, gaining License and CodeRabbit Reviews, every badge a link.

## Docs

`docs/DEPENDENCY_UPDATES.md`'s "Why Renovate is no longer staggered" becomes "Why neither bot is staggered", records the table's deletion, and keeps the 14 day arithmetic that applied to both bots all along. Remaining `BOT_SCHEDULE.md` references repointed; one historical mention stays and is not a link.

All hooks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dependency update checks now run daily instead of on staggered weekly schedules.
  * Docker Hub authentication is limited to merge-queue validation; pull request checks retain anonymous image-pull fallback.
  * Automated dependency approvals now better validate update data before allowing eligible merges.
  * Link checking excludes Grafana documentation links that cannot be reliably accessed by automated checks.

* **Documentation**
  * Updated dependency scheduling guidance to reflect daily checks and revised automation practices.

* **Style**
  * Refreshed README badges, including license and code review status badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->