### PR TITLE
fix: pin tests/requirements.txt exactly so the cooling window applies

### DIFF
--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -176,7 +176,7 @@ were both invisible until #94 sat unapproved.
 **The cooling window did not reach this surface.** `make bootstrap_tests`
 builds `tests/.venv` from scratch and runs `pip install -r
 tests/requirements.txt`, so a `>=` floor resolved to whatever was newest on
-PyPI at that moment. Dependabot's seven day `cooldown` governs when Dependabot
+PyPI at that moment. Dependabot's seven-day `cooldown` governs when Dependabot
 *proposes* a change, not what pip installs, so a package published an hour
 earlier went into the suite on the next run. The window the rest of this page
 is built around had no effect here at all, which is the more serious of the

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -168,6 +168,33 @@ than an image it pulls, `ghcr.io/notifiarr/notifiarr` because its service is com
 anyway. An unwatched pin is the thing this arrangement exists to prevent, and a year stale image
 is a worse starting point than a current one for whoever turns either service back on.
 
+## Why tests/requirements.txt is pinned exactly
+
+Every entry is `==`, not `>=`, and the difference mattered in two ways that
+were both invisible until #94 sat unapproved.
+
+**The cooling window did not reach this surface.** `make bootstrap_tests`
+builds `tests/.venv` from scratch and runs `pip install -r
+tests/requirements.txt`, so a `>=` floor resolved to whatever was newest on
+PyPI at that moment. Dependabot's seven day `cooldown` governs when Dependabot
+*proposes* a change, not what pip installs, so a package published an hour
+earlier went into the suite on the next run. The window the rest of this page
+is built around had no effect here at all, which is the more serious of the
+two problems: these nine packages are what the suite is written in, so a
+compromised one compromises the gate itself.
+
+**The update-type grader could not read a floor bump.**
+`bot-auto-merge.yml` approves a bot bump only when every entry in
+`updated-dependencies-json` is a patch or minor, and `fetch-metadata` cannot
+compute an update type without an exact prior version to compare against. It
+returns an empty string, the grader cannot grade that, so it withholds
+approval by design, and the pull request stays green but unapproved. That is
+the whole story of #94.
+
+Pinning fixed both without changing a single installed version: the pins are
+what `>=` was already resolving to. Dependabot maintains them from here, under
+the cooldown, and `Tests Verified` is what clears them.
+
 ## Security updates
 
 Both bots' security paths are alert driven and enabled on this repository, and neither reads the

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@
 # The cooling window did not apply. `make bootstrap_tests` builds tests/.venv
 # from scratch and runs `pip install -r tests/requirements.txt`, so a `>=`
 # floor resolves to whatever is newest on PyPI at that moment. Dependabot's
-# seven day `cooldown` only governs when Dependabot *proposes* a change, not
+# seven-day `cooldown` only governs when Dependabot *proposes* a change, not
 # what pip installs, so a package published an hour ago went straight into the
 # suite on the next run. The window that the rest of this repository's
 # dependency policy is built around had no effect on this surface at all.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,31 @@
-docker>=7.2.0
-json5>=0.12.1
-pytest>=9.1.1
-pytest-testinfra>=10.2.2
-pytest-xdist>=3.8.0
-python-dotenv>=1.2.2
-pyyaml>=6.0.3
-requests>=2.34.2
-urllib3>=2.7.0
+# Exact pins, not `>=` floors, for two reasons that both bite.
+#
+# The cooling window did not apply. `make bootstrap_tests` builds tests/.venv
+# from scratch and runs `pip install -r tests/requirements.txt`, so a `>=`
+# floor resolves to whatever is newest on PyPI at that moment. Dependabot's
+# seven day `cooldown` only governs when Dependabot *proposes* a change, not
+# what pip installs, so a package published an hour ago went straight into the
+# suite on the next run. The window that the rest of this repository's
+# dependency policy is built around had no effect on this surface at all.
+#
+# The update-type grader could not read them either. `bot-auto-merge.yml`
+# approves a bot bump only when every entry in dependabot's
+# `updated-dependencies-json` is a patch or minor, and `fetch-metadata` cannot
+# compute an update type for a floor bump, since there is no exact prior
+# version to compare. It reports an empty string, which the grader cannot
+# grade, so it withholds approval and the pull request sits green but
+# unapproved. #94 is exactly that.
+#
+# Pinned to what `>=` was already resolving to, so this is a lockfile of
+# current behavior rather than a change of versions, and every one of these
+# releases is more than seven days old as of 2026-09-03. Dependabot maintains
+# them from here, under the cooldown, and the suite is what clears them.
+docker==7.2.0
+json5==0.15.0
+pytest==9.1.1
+pytest-testinfra==10.2.2
+pytest-xdist==3.8.0
+python-dotenv==1.2.3
+pyyaml==6.0.3
+requests==2.34.2
+urllib3==2.7.0


### PR DESCRIPTION
Nine `>=` floors become nine `==` pins. **No installed version changes** — the
pins are what those floors were already resolving to.

Found while working out why #94 sits green but unapproved. There are two
problems, and the second one is the serious one.

## The seven day cooling window never reached this surface

`make bootstrap_tests` builds `tests/.venv` from scratch and runs
`pip install -r tests/requirements.txt`, so a `>=` floor resolves to whatever
is newest on PyPI **at that moment**.

Dependabot's `cooldown` governs when Dependabot *proposes* a change, not what
pip installs. So a package published an hour ago went into the suite on the
next run, entirely outside the window the rest of
`docs/DEPENDENCY_UPDATES.md` is built around.

These nine packages are what the test suite is written in. A compromised one
compromises the gate that clears every other dependency in the repository, so
this is the surface where the window mattered most and reached least.

## The update-type grader could not read a floor bump

`bot-auto-merge.yml` approves a bot bump only when every entry in
`updated-dependencies-json` is a patch or minor. `fetch-metadata` cannot
compute an update type without an exact prior version to compare against, so
it returns an empty string, which the grader refuses to vouch for. The pull
request then stays green but unapproved, forever.

That is the whole story of #94, which proposes exactly the `json5` 0.15.0 and
`python-dotenv` 1.2.3 that this pins. **#94 can be closed once this merges.**

## Safety of the pinned versions

Checked every one against PyPI upload timestamps: the newest is `python-dotenv`
1.2.3 at 17 days old, the rest range from 55 to 522 days. So pinning does not
import the risk the cooling window exists to prevent.

| package | pinned | age |
| --- | --- | --- |
| docker | 7.2.0 | 55d |
| json5 | 0.15.0 | 75d |
| pytest | 9.1.1 | 76d |
| pytest-testinfra | 10.2.2 | 522d |
| pytest-xdist | 3.8.0 | 429d |
| python-dotenv | 1.2.3 | 17d |
| pyyaml | 6.0.3 | 342d |
| requests | 2.34.2 | 111d |
| urllib3 | 2.7.0 | 118d |

## Verification

Built a fresh venv from the pinned file: all nine resolve with no conflicts and
resolve to exactly the pinned versions. Offline suites pass against it, 158
passed and 17 skipped. All pre-commit hooks pass.

From here Dependabot maintains these under the cooldown, `Pin Only` already
covers `tests/requirements.txt`, and the grader can finally read the bumps, so
they auto-approve like every other ecosystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Pinned test-suite dependencies to exact versions for more consistent and reproducible test runs.
  - Updated two test dependencies to newer resolved versions.

- **Documentation**
  - Added guidance explaining the rationale for exact dependency pinning and how automated updates are managed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->