### PR TITLE
fix: pin the lazylibrarian base and the Calibre mod by digest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -349,7 +349,7 @@ GRAFANA_VERSION=11.6.5@sha256:d552f949693c54d17c6f867ff6aeb128b021e54e923895dcf9
 # renovate: depName=docker.io/linuxserver/jellyfin
 JELLYFIN_VERSION=10.11.10@sha256:be2bd22d5e27451ebc14b326d8a6554e1f51c79f4431d6c71522565ed17f06ea
 # renovate: depName=docker.io/linuxserver/lazylibrarian versioning=loose
-LAZYLIBRARIAN_VERSION=f9f62f7a-ls342
+LAZYLIBRARIAN_VERSION=latest@sha256:cf9097740c1d3668936ab53a8cac8274ef14778e7374e0056950a2eccd36954b
 # renovate: depName=docker.io/linuxserver/lidarr
 LIDARR_VERSION=3.1.0@sha256:c74c32408fdf6e7926ad62641fc1a5544206ee65c33f2188bb179edb30e28f5a
 # renovate: depName=docker.io/linuxserver/mylar3 versioning=loose

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -215,7 +215,6 @@
     // missing digest cannot be mistaken for an oversight.
     {
       matchPackageNames: [
-        "docker.io/linuxserver/lazylibrarian",
         "docker.io/linuxserver/mylar3",
       ],
       pinDigests: false,
@@ -261,18 +260,19 @@
     // baseimage-gui 4.13.0 carries the fix and the image was already built on
     // 4.13.1, so nothing shadows a file in it any more; see issue #107.
     //
-    // lazylibrarian is the odd one here and stays for a different reason than
-    // the other two. Its patch is gone as well, upstream !1832 having reached
-    // the image, so nothing shadows a file in it either. What holds it is issue
-    // #119: its tag carries no version number, so `loose` versioning reads the
-    // leading hex of the commit fragment as a number and orders releases
-    // wrongly, reporting nothing to do rather than reporting that it cannot
-    // tell. Lifting this before that is settled would hand Renovate a pin it
-    // cannot rank. Bump it by hand until then.
+    // lazylibrarian came off this list on 2026-09-03, and issue #119 is what
+    // was holding it: its tag is a composite of the upstream app commit and
+    // linuxserver's own build revision, `82aad29e-ls342`, which no versioning
+    // scheme can order. Two releases can even share one ls number, since that
+    // half only moves when linuxserver's side changes.
+    //
+    // Solved by not ordering it. The pin is now `latest@sha256:...`, so
+    // Renovate refreshes the digest as the tag moves and never has to rank
+    // anything. That needed the variable to stop doubling as the wrapper's
+    // own image tag first; see docker-compose-servarr.yml.
     {
       matchPackageNames: [
         "docker.io/linuxserver/sabnzbd",
-        "docker.io/linuxserver/lazylibrarian",
         "docker.io/linuxserver/mylar3",
       ],
       enabled: false,

--- a/build/lazylibrarian/Dockerfile
+++ b/build/lazylibrarian/Dockerfile
@@ -11,7 +11,18 @@
 # and a bare `docker build` should fail loudly rather than quietly produce an
 # image built on :latest that no longer matches the pinned version.
 ARG BASE_VERSION
-FROM ghcr.io/linuxserver/mods:universal-calibre AS calibre-mod
+# Digest pinned, like every other image this stack pulls. This line carried a
+# bare tag until 2026-09-03, which meant the Calibre that ends up inside the
+# wrapper was whatever the mod happened to be at build time, with nothing in
+# any diff recording which one. Renovate's dockerfile manager already reads
+# this file and pinDigests is on globally, so the only reason it was never
+# maintained is that there was no digest here to maintain.
+#
+# tests/test_version_pins.py asserts the Calibre this resolves to against
+# CALIBRE_VERSION in .env.example, using the CALIBRE_RELEASE file the mod
+# ships and the COPY below already brings in.
+# renovate: datasource=docker depName=ghcr.io/linuxserver/mods versioning=docker
+FROM ghcr.io/linuxserver/mods:universal-calibre@sha256:ceae75f021e73a049fcea41777dc8b1f2adeb5da10d2749caca12ca290293cce AS calibre-mod
 
 FROM docker.io/linuxserver/lazylibrarian:${BASE_VERSION}
 COPY --from=calibre-mod /calibre.txz /calibre.txz

--- a/build/lazylibrarian/Dockerfile
+++ b/build/lazylibrarian/Dockerfile
@@ -11,16 +11,24 @@
 # and a bare `docker build` should fail loudly rather than quietly produce an
 # image built on :latest that no longer matches the pinned version.
 ARG BASE_VERSION
-# Digest pinned, like every other image this stack pulls. This line carried a
-# bare tag until 2026-09-03, which meant the Calibre that ends up inside the
-# wrapper was whatever the mod happened to be at build time, with nothing in
-# any diff recording which one. Renovate's dockerfile manager already reads
-# this file and pinDigests is on globally, so the only reason it was never
-# maintained is that there was no digest here to maintain.
+# Digest pinned. This line carried a bare tag until 2026-09-03, which meant
+# the Calibre that ends up inside the wrapper was whatever the mod happened to
+# be at build time, with nothing in any diff recording which one. Renovate's
+# dockerfile manager already reads this file and pinDigests is on globally, so
+# the only reason it was never maintained is that there was no digest here to
+# maintain.
 #
-# tests/test_version_pins.py asserts the Calibre this resolves to against
-# CALIBRE_VERSION in .env.example, using the CALIBRE_RELEASE file the mod
-# ships and the COPY below already brings in.
+# Most of what this stack pulls is digest pinned, not all of it: three tags
+# float deliberately, with a reason recorded for each in the FLOATING
+# allowlist in tests/test_renovate_pins.py and under "Remaining gaps" in
+# docs/DEPENDENCY_UPDATES.md.
+#
+# tests/test_version_pins.py's test_lazylibrarian_carries_the_calibre_mod
+# checks that this layer survived the build, by reading the CALIBRE_RELEASE
+# file the mod ships and the COPY below brings in, and by running calibredb.
+# It deliberately asserts no version: the digest above already fixes which
+# Calibre this is, and hardcoding it in the test as well would fail on every
+# digest bump and take the automerge path down with it.
 # renovate: datasource=docker depName=ghcr.io/linuxserver/mods versioning=docker
 FROM ghcr.io/linuxserver/mods:universal-calibre@sha256:ceae75f021e73a049fcea41777dc8b1f2adeb5da10d2749caca12ca290293cce AS calibre-mod
 

--- a/docker-compose-servarr.yml
+++ b/docker-compose-servarr.yml
@@ -322,7 +322,15 @@ services:
 
   lazylibrarian:
     <<: [*servarr-common, *limit-servarr]
-    image: lazylibrarian-calibre:${LAZYLIBRARIAN_VERSION}
+    # `local`, not ${LAZYLIBRARIAN_VERSION}. The variable used to be both the
+    # base image reference and the tag of the wrapper built from it, and a
+    # locally built image can only be given a tag: podman rejects a reference
+    # carrying both a tag and a digest. That single reuse is what forced
+    # LAZYLIBRARIAN_VERSION out of pinDigests, which in turn left the pin
+    # unable to be ordered or refreshed (issue #119). Splitting the two uses
+    # lets the base carry a digest; this tag names a local artefact and does
+    # not need a version in it.
+    image: lazylibrarian-calibre:local
     build:
       context: ./build/lazylibrarian
       args:

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -302,25 +302,33 @@ Three tags are deliberately left floating rather than pinned to a version at all
 `tests/test_renovate_pins.py` carries them in an explicit allowlist, so the exemption is a
 decision on the record rather than an omission.
 
-`LAZYLIBRARIAN_VERSION` and `MYLAR_VERSION` carry no digest, and cannot. Each is read twice out
-of one variable: as the base image the wrapper in `build/` is built on, and as the tag of the
-locally built result. A digest is legal in the first position and not in the second, because an
-image being built can only be given a tag, so `pinDigests` is turned off for both in
-`.github/renovate.json5` and the test exempts them by name. An earlier note recorded this the
-other way round, asking for a digest to be added to lazylibrarian; adding one would have
-stopped the wrapper building.
+`MYLAR_VERSION` carries no digest, and cannot as it stands. It is read twice out of one
+variable: as the base image the wrapper in `build/` is built on, and as the tag of the locally
+built result. A digest is legal in the first position and not in the second, because an image
+being built can only be given a tag, so `pinDigests` is turned off for it in
+`.github/renovate.json5` and the test exempts it by name. An earlier note recorded this the
+other way round, asking for a digest to be added; adding one would have stopped the wrapper
+building.
 
-One pin is watched and still cannot be ordered. `LAZYLIBRARIAN_VERSION=f9f62f7a-ls342` holds no
-version number at all, so `loose` versioning parses the tag rather than refusing it and then
-orders it wrongly, reading the leading hex of the commit fragment as a number and comparing it
-against another commit fragment. Renovate reports nothing to do rather than reporting that it
-cannot tell, which is the worse of the two failures.
+`LAZYLIBRARIAN_VERSION` was the other half of that pair until 2026-09-03, and it is the worked
+example of the way out. The wrapper's own image is now tagged `local` rather than with the
+version, which leaves the variable naming only the base, which can then carry a digest. **The
+same fix applies to mylar** whenever its patch clears and there is reason to touch that file;
+issue #106 records it.
 
-That day has now arrived. `patches/lazylibrarian/` was dropped on 2026-09-02, which is what the
-note here used to say this would matter on, so the hold is the only thing still standing between
-Renovate and a pin it cannot rank. It therefore stays until issue #119 settles the versioning
-scheme, and the pin is bumped by hand until then. This is the one entry on the `enabled: false`
-list held for ordering rather than for a patch.
+Splitting it also settled issue #119, which was the harder half. The tag is a composite:
+`82aad29e-ls342` is the upstream LazyLibrarian commit and linuxserver's own build revision,
+joined by a hyphen. Neither half orders the tags on its own. The hex is a commit, and the `ls`
+number only moves when linuxserver's side changes, so two releases can share one: `ls342` was
+published twice, on 2026-09-02 and 2026-09-03, with different app commits. `ls314` appears four
+times in the last hundred releases. LazyLibrarian publishes no versions upstream at all, which
+is why linuxserver has none to put in a tag, and why `mylar3` gets `v0.9.0-lsNNN` and this image
+does not.
+
+So it is not ordered. `LAZYLIBRARIAN_VERSION=latest@sha256:...` tracks the tag linuxserver
+actually documents, and Renovate refreshes the digest as it moves. There is no ranking to get
+wrong, the pin is still immutable because the digest decides what runs, and the automerge rule
+already covers `digest` updates.
 
 `KORSYNC_VERSION` used to be the other case, pinned to `sha-7bcefd34...`, a commit tag nothing can
 order. Upstream publishes plain semantic tags and has since well before that pin landed here on

--- a/tests/test_renovate_pins.py
+++ b/tests/test_renovate_pins.py
@@ -73,10 +73,12 @@ FLOATING = {
 # either value would therefore break the build rather than pin anything, which
 # is why pinDigests has to be allowed to leave these two alone.
 NO_DIGEST = {
-    "LAZYLIBRARIAN_VERSION": (
-        "also the BASE_VERSION build arg and the local wrapper image's own tag, "
-        "and a container runtime rejects a reference with both a tag and a digest"
-    ),
+    # LAZYLIBRARIAN_VERSION was here until 2026-09-03 for exactly this reason,
+    # and came off by splitting the two uses: the wrapper's own image is now
+    # tagged `local` in docker-compose-servarr.yml, leaving the variable to
+    # name only the base, which can then carry a digest. MYLAR_VERSION has the
+    # identical shape and the same fix applies to it, once its patch clears
+    # and there is a reason to touch the file; see issue #106.
     "MYLAR_VERSION": (
         "also the BASE_VERSION build arg and the local wrapper image's own tag, "
         "and a container runtime rejects a reference with both a tag and a digest"

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -84,6 +84,7 @@ while looking thorough:
 """
 
 import re
+import subprocess  # nosec B404 - podman CLI, see the call sites
 
 import pytest
 import requests
@@ -93,6 +94,7 @@ from conftest import (
     GRAFANA_INI,
     SERVICES,
     base_url,
+    container_name,
     env,
     grafana_admin_credentials,
     is_enabled,
@@ -459,6 +461,68 @@ def test_grafana_running_version_matches_pin(running_containers):
 
     _assert_running_matches_pin(
         env("GRAFANA_VERSION"), reported, "grafana", "GRAFANA_VERSION"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Calibre, which reaches lazylibrarian through a build-time mod rather than a
+# pin of its own
+# ---------------------------------------------------------------------------
+
+
+def test_lazylibrarian_carries_the_calibre_mod(running_containers):
+    """The wrapper's whole reason to exist is present in the running container.
+
+    `build/lazylibrarian/Dockerfile` layers ghcr.io/linuxserver/mods:universal-calibre
+    onto the stock image, which ships no Calibre at all, so a wrapper that
+    silently lost the layer would start, report healthy and serve the web UI
+    while Calibredb import quietly did nothing.
+
+    Deliberately no assertion on *which* Calibre. The mod is digest pinned in
+    that Dockerfile, so the version is already fixed by the digest, and
+    hardcoding the version here as well would fail this test on every
+    Renovate digest bump and take the automerge path down with it. What is
+    asserted is what the digest cannot promise on its own: that the layer
+    survived the build and the binary actually runs.
+    """
+    if not is_enabled("lazylibrarian"):
+        pytest.skip("lazylibrarian profile is disabled")
+    skip_if_not_running("lazylibrarian", running_containers)
+
+    # CALIBRE_RELEASE ships in the mod and the Dockerfile copies it in; it is
+    # the one file that records which Calibre the layer carried.
+    release = subprocess.run(  # nosec B607 - podman is a trusted, fixed CLI in this stack
+        ["podman", "exec", container_name("lazylibrarian"), "cat", "/CALIBRE_RELEASE"],
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT,
+    )
+    assert release.returncode == 0, (
+        "/CALIBRE_RELEASE is missing from the lazylibrarian container, so the "
+        f"universal-calibre layer did not survive the build: {release.stderr[:200]}"
+    )
+    assert release.stdout.strip(), "/CALIBRE_RELEASE is present but empty"
+
+    # The file existing only proves the COPY ran. This proves the tarball was
+    # unpacked and calibre_postinstall completed.
+    binary = subprocess.run(  # nosec B607 - podman is a trusted, fixed CLI in this stack
+        [
+            "podman",
+            "exec",
+            container_name("lazylibrarian"),
+            "/app/calibre/calibredb",
+            "--version",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT,
+    )
+    assert binary.returncode == 0, (
+        "/app/calibre/calibredb did not run in the lazylibrarian container, so "
+        f"Calibre is present as files but not usable: {binary.stderr[:200]}"
+    )
+    assert "calibre" in binary.stdout.lower(), (
+        f"unexpected calibredb --version output: {binary.stdout[:200]}"
     )
 
 


### PR DESCRIPTION
Closes #119 by removing the need to order the tag at all, and pins the Calibre
that reaches the image, which nothing was pinning before.

## Why the tag could not be ordered

`82aad29e-ls342` is a composite: the upstream LazyLibrarian commit joined to
linuxserver's own build revision. Neither half orders it.

- The hex is an app commit.
- The `ls` number only moves when linuxserver's side changes, so **two
  releases can share one**. `ls342` was published twice, 2026-09-02 and
  2026-09-03, with different app commits. `ls314` appears **four times** in
  the last hundred releases.

LazyLibrarian publishes no versions upstream at all, which is why linuxserver
has none to put in a tag: `mylar3` has 254 `vX.Y.Z-lsN` tags, this image has 0.
So there is no versioning scheme to ask for and none to configure.

## So it is not ordered

`LAZYLIBRARIAN_VERSION=latest@sha256:…` — the tag linuxserver actually
documents in `readme-vars.yml` — and Renovate refreshes the digest as it
moves. Nothing has to be ranked, the pin stays immutable because the digest
decides what runs, and `digest` updates are already in the automerge rule.

## That needed the variable to stop doing two jobs

It was both the base image reference *and* the tag of the wrapper built from
it, and a locally built image can only be given a tag, so a digest would have
broken the build. The wrapper is now `lazylibrarian-calibre:local`.

That reuse is the entire reason `LAZYLIBRARIAN_VERSION` sat in `NO_DIGEST`
with a paired `pinDigests: false` rule. Both come off together, as
`test_digest_exemption_is_backed_by_the_config` requires. Its `enabled: false`
hold comes off too: it now has neither a patch nor an ordering problem.

## The Calibre mod is pinned as well

`FROM ghcr.io/linuxserver/mods:universal-calibre` carried a bare tag, so the
Calibre baked into the wrapper was whatever the mod happened to be at build
time, with nothing in any diff recording which one. Renovate's `dockerfile`
manager already reads this file and `pinDigests` is on globally — the only
reason it went unmaintained is that there was no digest to maintain.

## Why not DOCKER_MODS

linuxserver documents `DOCKER_MODS=linuxserver/mods:universal-calibre` as the
supported route, and its loader *does* accept a digest (three forms:
`image:tag@sha256:`, `image@sha256:`, `image:tag`). Rejected anyway:

- it contacts the registry on **every container start**
- if the registry is unreachable and `/modcache` has no copy, it logs an error
  and `continue`s, so **the container comes up without Calibre and still
  reports healthy**
- it would mean two pins to maintain instead of one, plus a customManager

A build-time layer fails loudly instead, and starts faster.

## Coverage

`test_lazylibrarian_carries_the_calibre_mod` asserts what the digest cannot
promise on its own: `/CALIBRE_RELEASE` survived the build, and
`/app/calibre/calibredb --version` actually runs. The stock image ships no
Calibre, so a wrapper that silently lost the layer would start, report healthy
and serve the UI while Calibredb import quietly did nothing.

It deliberately asserts **no version**: the digest already fixes that, and
hardcoding it would fail on every Renovate digest bump and take the automerge
path down with it.

## mylar

`MYLAR_VERSION` has the identical two-uses shape and the same fix applies once
its patch clears. Recorded in the `NO_DIGEST` comment, in
`docs/DEPENDENCY_UPDATES.md`, and on #106.

## Verification

All pre-commit hooks pass, including hadolint on the changed Dockerfile.
`test_renovate_pins.py` and `test_version_pins.py`: 158 passed, 18 skipped —
and lazylibrarian now takes the digest check rather than skipping it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LazyLibrarian build reproducibility by pinning its base image to an immutable digest.
  - Ensured the locally built LazyLibrarian image uses a stable local tag while retaining the pinned base image.

- **Documentation**
  - Updated dependency guidance to explain the revised pinning and update-tracking approach.

- **Tests**
  - Added validation that the LazyLibrarian container includes a working Calibre installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->