### PR TITLE
fix: stop the review nudge posting as github-actions[bot]

### DIFF
--- a/.github/workflows/coderabbit-review-queue.yml
+++ b/.github/workflows/coderabbit-review-queue.yml
@@ -35,14 +35,18 @@ jobs:
     name: Ask for one missing review
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      # For the comment. Reading statuses and comments needs nothing extra on a
-      # public repository.
-      pull-requests: write
+    # No permissions beyond the `contents: read` above. GITHUB_TOKEN no longer
+    # posts the comment, so it no longer needs `pull-requests: write`, and
+    # reading pull requests, statuses and comments needs nothing extra on a
+    # public repository. The comment is posted with CODERABBIT_NUDGE_TOKEN,
+    # which carries its own scope.
     steps:
       - name: Find one head with no review, and ask
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Only the one comment that CodeRabbit has to see as human-authored
+          # reads this; see the note beside that call.
+          CODERABBIT_NUDGE_TOKEN: ${{ secrets.CODERABBIT_NUDGE_TOKEN }}
           REPO: ${{ github.repository }}
           # Forks are capped so a contributor's pull request cannot collect a
           # comment every hour forever while the quota is exhausted. Our own
@@ -236,11 +240,34 @@ jobs:
             fi
 
             echo "#$number (${sha:0:8}): $reason. Asking for a review."
-            # GITHUB_TOKEN is enough. The suppression that bites elsewhere in
-            # this repository, where an event a workflow's own token creates
-            # starts no further workflow, does not apply: CodeRabbit is a GitHub
-            # App on a webhook, not a workflow trigger.
-            gh pr comment "$number" --repo "$REPO" --body "$(printf '@coderabbitai review\n\n%s' "$marker")"
+            # Not GITHUB_TOKEN, and the reason is not the one the previous
+            # comment here gave. That comment argued GITHUB_TOKEN was fine
+            # because CodeRabbit is a GitHub App on a webhook rather than a
+            # workflow trigger, so the usual "an event a workflow's own token
+            # creates starts no further workflow" suppression does not apply.
+            # True, and beside the point: CodeRabbit silently ignores an
+            # `@coderabbitai review` command posted by a bot account, exactly
+            # as it ignores a pull request authored by one. GITHUB_TOKEN posts
+            # as github-actions[bot], so every nudge this workflow has ever
+            # sent from this repository was discarded without a reply, a
+            # status, or a log line anywhere.
+            #
+            # Measured, not assumed: on rsync-crypt#33 the same command text
+            # was posted by both accounts on the same pull request.
+            # ivan-pinatti drew a reply within about seven seconds every time;
+            # github-actions[bot] drew nothing, three times out of three. The
+            # other five repositories in this organization already post with
+            # the token below; this one was missed.
+            #
+            # CODERABBIT_NUDGE_TOKEN is a fine grained personal access token
+            # scoped to Issues read and write, stored as an org secret whose
+            # visibility is restricted to the repositories that need it. Only
+            # this call uses it; everything else here keeps reading through
+            # GITHUB_TOKEN. If it is missing or revoked this fails loudly with
+            # a 401 or 403, which is correct: falling back to GITHUB_TOKEN
+            # would silently restore the bug.
+            GH_TOKEN="${CODERABBIT_NUDGE_TOKEN}" gh pr comment "$number" --repo "$REPO" \
+              --body "$(printf '@coderabbitai review\n\n%s' "$marker")"
 
             # One per run. The quota frees a slot at a time, and firing a batch
             # into an exhausted window bounces all of them and wastes the slot

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -211,6 +211,20 @@ intervention.
   thread of its own, since a review cannot fix any of those and the quota slot
   would be wasted.
 
+  **That comment is posted with `CODERABBIT_NUDGE_TOKEN`, not `GITHUB_TOKEN`,
+  and the distinction is the whole thing.** CodeRabbit silently ignores an
+  `@coderabbitai review` command posted by a bot account, the same way it
+  ignores a pull request authored by one: no review, no decline, no rate limit
+  notice, nothing. `GITHUB_TOKEN` posts as `github-actions[bot]`, so a nudge
+  sent that way is discarded without a trace anywhere.
+
+  This repository sent them that way until 2026-09-03, which is why its bot
+  pull requests kept needing a human to ask by hand while the other five
+  repositories recovered on their own. Measured on `rsync-crypt#33`, where the
+  same command text was posted by both accounts on one pull request:
+  `ivan-pinatti` drew a reply within about seven seconds every time,
+  `github-actions[bot]` drew nothing, three times out of three.
+
   The quota itself is worth meeting here rather than being surprised by it:
   this repository is on CodeRabbit's Open Source plan, which scales the
   included review count with the repository's star count rather than holding

--- a/docs/MERGE_PIPELINE.md
+++ b/docs/MERGE_PIPELINE.md
@@ -216,7 +216,10 @@ intervention.
   `@coderabbitai review` command posted by a bot account, the same way it
   ignores a pull request authored by one: no review, no decline, no rate limit
   notice, nothing. `GITHUB_TOKEN` posts as `github-actions[bot]`, so a nudge
-  sent that way is discarded without a trace anywhere.
+  sent that way is discarded without a CodeRabbit reply, status, or rate limit
+  notice. The comment itself is still posted and still visible on the pull
+  request, which is what makes this hard to spot: the nudge looks like it
+  worked and nothing downstream of it ever happens.
 
   This repository sent them that way until 2026-09-03, which is why its bot
   pull requests kept needing a human to ask by hand while the other five


### PR DESCRIPTION
**Every `@coderabbitai review` nudge this repository has ever sent was silently
discarded.**

`coderabbit-review-queue.yml` posted its comment with `GITHUB_TOKEN`, which
posts as `github-actions[bot]`. CodeRabbit silently ignores that command from a
bot account, exactly as it ignores a pull request authored by one: no review,
no decline, no rate limit notice, no log line anywhere.

That is why this repository's bot pull requests kept needing a human to ask by
hand, while the other five in the organization recovered on their own. All five
already post with `CODERABBIT_NUDGE_TOKEN`. This one was missed.

| repo | posting token |
| --- | --- |
| rsync-crypt | `CODERABBIT_NUDGE_TOKEN` |
| pre-commit-checklists | `CODERABBIT_NUDGE_TOKEN` |
| pre-commit-checklists-demo | `CODERABBIT_NUDGE_TOKEN` |
| github-template | `CODERABBIT_NUDGE_TOKEN` |
| .github | `CODERABBIT_NUDGE_TOKEN` |
| **docker-torrent-box-with-vpn** | **`GITHUB_TOKEN`** |

## The old comment was right about the wrong thing

It argued `GITHUB_TOKEN` was fine because CodeRabbit is a GitHub App on a
webhook rather than a workflow trigger, so the usual "an event a workflow's own
token creates starts no further workflow" suppression does not apply.

That is true, and it is not the constraint that governs here. Two different
rules, and the comment answered the one that did not bite.

## Measured, not assumed

`rsync-crypt#33` happens to be a controlled experiment: the identical command
text, on one pull request, from both accounts.

| Time (UTC) | Author | CodeRabbit |
| --- | --- | --- |
| 2026-08-26 20:16:22 | `ivan-pinatti` | replied 20:16:29 |
| 2026-08-26 22:19:31 | `github-actions[bot]` | nothing |
| 2026-08-27 03:22:58 | `github-actions[bot]` | nothing |
| 2026-08-27 03:39:13 | `ivan-pinatti` | replied 03:39:21 |
| 2026-08-27 14:17:36 | `ivan-pinatti` | replied 14:17:42 |
| 2026-08-27 14:23:04 | `github-actions[bot]` | nothing |
| 2026-08-27 14:57:13 | `ivan-pinatti` | replied 14:57:20 |

Eight of nine human commands drew a reply in about seven seconds. All three bot
commands drew nothing.

## Scope

`CODERABBIT_NUDGE_TOKEN` is already in the org secret's selected-repository
list for this repository, so this is a code change only, no secret work needed.

The job also drops `pull-requests: write`, which existed solely for the comment
`GITHUB_TOKEN` no longer posts. There is deliberately no fallback to
`GITHUB_TOKEN` if the PAT is missing: failing loudly with a 401 is correct,
because a fallback would silently restore this bug.

`docs/MERGE_PIPELINE.md` records the rule so the next person does not
re-derive it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated CodeRabbit review reminders so review requests are processed reliably.
  * Automation now reports authentication failures clearly instead of silently falling back to an alternate credential.
  * Reduced unnecessary workflow permissions for improved security.

* **Documentation**
  * Updated merge-pipeline documentation with the required authentication setup and troubleshooting details.
  * Documented observed behavior for review requests submitted by automated accounts, including silent rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->