### PR TITLE
fix: build LazyLibrarian and Mylar before the readiness wait, not during it

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -706,6 +706,22 @@ jobs:
           echo "::error::Could not pull the images after 3 attempts."
           exit 1
 
+      - name: Build custom container images
+        # `make bootstrap` builds LazyLibrarian and Mylar before it ever calls
+        # `start` (they have no upstream image; compose builds them from the
+        # Dockerfiles under build/), but this workflow replicates bootstrap's
+        # steps one by one instead of calling it, and this one had been left
+        # out. Without it, `make start` built lazylibrarian for the first time
+        # inline, and assert-stack-started.sh's 300s readiness clock (see
+        # `Wait for containers to be ready` below) started counting before
+        # that build finished, so a slow apt mirror for the Calibre
+        # dependency install (over 4 minutes fetching 60MB at times) burned
+        # the whole budget on a build and left none for any container to
+        # actually come up: three unrelated pull requests failed this way in
+        # the same run.
+        timeout-minutes: 10
+        run: make build_images
+
       - name: Start stack
         # Every long step carries its own timeout. Without them the job-level
         # 25 minutes was the only bound, so a single stuck step burned the


### PR DESCRIPTION
PRs #157, #158 and #159 were all failing Integration Tests despite being unrelated pin only diffs (Renovate updates to `.env.example`, `.tool-versions`, `.pre-commit-config.yaml`). All three failed the same way: `make start` reported 32 of 34 services not running after 300s.

The actual cause has nothing to do with any of those diffs. `make bootstrap` builds the LazyLibrarian and Mylar images (`make build_images`) before it ever calls `start`, since those two have no upstream image and are built from local Dockerfiles. This workflow reimplements bootstrap's steps one at a time instead of calling it, and the build step had been left out. `make start` then built lazylibrarian for the first time inline, and `assert-stack-started.sh`'s 300s readiness clock started counting before that build finished.

In all three failing runs, the Calibre dependency install inside that Dockerfile hit a slow apt mirror (`archive.ubuntu.com`), taking 4 to 6 minutes to fetch about 60MB. That alone ate the whole 300s budget, so no container had a chance to come up.

Fix: add a "Build custom container images" step calling `make build_images`, placed before "Start stack" and after "Pull container images", mirroring how that step was already split out of `make start` for the same reason.

Verified against the three failing run logs; all show the build still in progress at the 300s mark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Integration tests now build custom container images before starting the test stack.
  * Added a 10-minute timeout for the image-building step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->