### PR TITLE
Tolerate a slow docker compose plugin probe in test_compose_available

### DIFF
--- a/tests/test_prerequisites.py
+++ b/tests/test_prerequisites.py
@@ -62,7 +62,19 @@ def test_docker_version():
 
 
 def test_compose_available():
-    has_docker_compose_plugin = run(["docker", "compose", "version"]).returncode == 0
+    # A slow `docker compose version` counts as "this flavour did not
+    # answer", not as a hard failure of the whole test, otherwise it aborts
+    # the test before the other two flavours are ever checked, even when one
+    # of them is perfectly usable. Fixed at this call site rather than in
+    # run() itself: run() is shared by every other probe in this file, and
+    # broadening it there would change what a timeout means for all of them,
+    # not just this one.
+    try:
+        has_docker_compose_plugin = (
+            run(["docker", "compose", "version"]).returncode == 0
+        )
+    except subprocess.TimeoutExpired:
+        has_docker_compose_plugin = False
     has_docker_compose_standalone = shutil.which("docker-compose") is not None
     has_podman_compose = shutil.which("podman-compose") is not None
     assert (


### PR DESCRIPTION
Fixes #123.

## The bug

`test_compose_available` asserts one of three compose flavours exists: the
`docker compose` plugin, standalone `docker-compose`, or `podman-compose`. The
probe for the first flavour runs through `run()`, which passes `timeout=10` to
`subprocess.run`, and a timeout there raises `subprocess.TimeoutExpired`
instead of returning a non zero exit status. A merely slow `docker compose
version` therefore aborted the whole test before the other two flavours were
ever checked, even when one of them, `podman-compose` in CI, was present and
would have satisfied the assertion.

## The fix

Catch `subprocess.TimeoutExpired` around the `docker compose version` probe
inside `test_compose_available` only, treating a timeout as "this flavour did
not answer" (`has_docker_compose_plugin = False`) rather than letting the
exception propagate. The assertion still fails when none of the three
flavours is genuinely available, verified locally by monkeypatching `run()`
and `shutil.which()`.

## Why the call site and not `run()`

The issue itself raises this as an open question, and I chose the narrow
fix. `run()` is shared by every other probe in this file (`docker --version`,
`docker info`, `lsmod`, `modinfo`, `make --version`, `yq --version`,
`xmlstarlet --version`, several `git` invocations), and making it swallow
`TimeoutExpired` there would change what a timeout means for all of those
callers at once, most of which have no fallback to move on to and should
keep failing loudly if they hang. Fixing only this call site keeps the
blast radius to the one place that actually has alternatives to check.

## Testing

- `tests/.venv/bin/pytest tests/test_prerequisites.py::test_compose_available -v`
- Monkeypatched `run()` to raise `TimeoutExpired` for the `docker compose`
  probe with `podman-compose` present: passes.
- Monkeypatched `shutil.which()` to report nothing present: raises
  `AssertionError` as expected.
- `pre-commit run --all-files`: all hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved prerequisite checks so slow Docker Compose version responses no longer interrupt validation of other supported Compose variants.
  - Timeouts are handled gracefully during environment detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->