### PR TITLE
Fail arr health test on unreachable download clients

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,6 +269,33 @@ VPN_NETWORKED = {
 }
 
 
+# Health messages that mean a download client is unreachable, which is a core
+# function of this stack, as opposed to everything else these endpoints report,
+# which is largely environmental (no indexers, no usenet provider, no real
+# trackers configured) and stays a warning instead. Keep this list short:
+# turning every health message into a failure would make the health tier
+# useless in a test environment shaped like that.
+DOWNLOAD_CLIENT_UNREACHABLE_SUBSTRINGS = (
+    # The exact failure #124 was filed over: a stale GLUETUN_SERVICES_IP left
+    # every arr unable to reach qBittorrent, and the test only warned about it.
+    "unable to communicate with qbittorrent",
+    # SABnzbd has the identical failure shape as qBittorrent, see #112.
+    "unable to communicate with sabnzbd",
+)
+
+
+def is_download_client_unreachable(message: str) -> bool:
+    """True when a servarr health message means a download client cannot be reached.
+
+    Everything else these endpoints report keeps warning rather than failing,
+    see test_arr_health_response_empty in test_services.py.
+    """
+    lowered = message.lower()
+    return any(
+        substring in lowered for substring in DOWNLOAD_CLIENT_UNREACHABLE_SUBSTRINGS
+    )
+
+
 def env(key: str, default: str = "") -> str:
     return ENV.get(key, default) or default
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,14 +304,26 @@ def is_download_client_unreachable(message) -> bool:
 def classify_arr_health_response(data: list) -> tuple[list, list]:
     """Split a servarr health endpoint's response into (failures, warn_only).
 
-    `data` is the JSON list a health endpoint returns, each item a dict with
-    at least a `message` key. This is the actual classification behind
-    test_arr_health_response_empty, pulled out so it can be exercised directly
-    against a fabricated response instead of only through is_download_client_unreachable.
+    `data` is the JSON list a health endpoint returns, each item normally a
+    dict with at least a `message` key. This is the actual classification
+    behind test_arr_health_response_empty, pulled out so it can be exercised
+    directly against a fabricated response instead of only through
+    is_download_client_unreachable. An item that is not a dict, or a dict with
+    no `message`, is malformed rather than a failure signal, so it goes to
+    warn_only unclassified instead of being stringified and matched against
+    the fail list, which could false positive on an unrelated message.
     """
-    messages = [item.get("message", str(item)) for item in data]
-    failures = [m for m in messages if is_download_client_unreachable(m)]
-    warn_only = [m for m in messages if m not in failures]
+    failures = []
+    warn_only = []
+    for item in data:
+        if not isinstance(item, dict) or "message" not in item:
+            warn_only.append(str(item))
+            continue
+        message = item["message"]
+        if is_download_client_unreachable(message):
+            failures.append(message)
+        else:
+            warn_only.append(message)
     return failures, warn_only
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,16 +284,35 @@ DOWNLOAD_CLIENT_UNREACHABLE_SUBSTRINGS = (
 )
 
 
-def is_download_client_unreachable(message: str) -> bool:
+def is_download_client_unreachable(message) -> bool:
     """True when a servarr health message means a download client cannot be reached.
 
     Everything else these endpoints report keeps warning rather than failing,
-    see test_arr_health_response_empty in test_services.py.
+    see test_arr_health_response_empty in test_services.py. A message that is
+    not a string, or missing entirely, is not a match rather than an error:
+    a malformed health payload should warn like any other unrecognized shape,
+    not blow up the whole tier.
     """
+    if not isinstance(message, str):
+        return False
     lowered = message.lower()
     return any(
         substring in lowered for substring in DOWNLOAD_CLIENT_UNREACHABLE_SUBSTRINGS
     )
+
+
+def classify_arr_health_response(data: list) -> tuple[list, list]:
+    """Split a servarr health endpoint's response into (failures, warn_only).
+
+    `data` is the JSON list a health endpoint returns, each item a dict with
+    at least a `message` key. This is the actual classification behind
+    test_arr_health_response_empty, pulled out so it can be exercised directly
+    against a fabricated response instead of only through is_download_client_unreachable.
+    """
+    messages = [item.get("message", str(item)) for item in data]
+    failures = [m for m in messages if is_download_client_unreachable(m)]
+    warn_only = [m for m in messages if m not in failures]
+    return failures, warn_only
 
 
 def env(key: str, default: str = "") -> str:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -129,6 +129,19 @@ def test_classify_arr_health_response_warns_only_on_environmental_messages():
     ]
 
 
+def test_classify_arr_health_response_treats_malformed_items_as_warnings():
+    """A malformed item is not a fail signal, it is just unrecognized.
+
+    None in the list, and a dict with no message key, must not be stringified
+    and matched against the fail list (that could false positive on an
+    unrelated message) or raise trying to call .lower() on it.
+    """
+    fabricated_response = [None, {"source": "SomeCheck", "type": "warning"}]
+    failures, warn_only = classify_arr_health_response(fabricated_response)
+    assert failures == []
+    assert warn_only == ["None", "{'source': 'SomeCheck', 'type': 'warning'}"]
+
+
 @pytest.mark.parametrize(
     "service_name",
     [

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,6 +6,7 @@ import urllib3
 
 from conftest import (
     SERVICES,
+    classify_arr_health_response,
     is_download_client_unreachable,
     is_enabled,
     read_api_key,
@@ -49,22 +50,20 @@ def test_service_api_health(service_name, running_containers):
     )
 
 
-def test_is_download_client_unreachable_fails_on_download_client_messages():
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Unable to communicate with QBittorrent. Connection refused",
+        "Unable to communicate with SABnzbd. Connection refused",
+    ],
+)
+def test_is_download_client_unreachable_fails_on_download_client_messages(message):
     """A download client message is the one thing this tier must fail on.
 
     No live stack needed: this exercises the classification function directly
-    with the fabricated payload shape a real health endpoint returns, per #124.
+    with the fabricated message shape a real health endpoint returns, per #124.
     """
-    fabricated_response = [
-        {
-            "source": "QbittorrentSettingsValidator",
-            "type": "error",
-            "message": "Unable to communicate with QBittorrent. Connection refused",
-            "wikiUrl": "https://wiki.servarr.com/sonarr/system#download-client-unavailable",
-        },
-    ]
-    messages = [item["message"] for item in fabricated_response]
-    assert any(is_download_client_unreachable(m) for m in messages)
+    assert is_download_client_unreachable(message)
 
 
 def test_is_download_client_unreachable_warns_on_environmental_messages():
@@ -73,6 +72,41 @@ def test_is_download_client_unreachable_warns_on_environmental_messages():
     A stack with no real indexers configured is expected, not broken, and
     this tier needs to keep passing against it.
     """
+    messages = [
+        "All indexers are unavailable due to failures",
+        "Indexers unavailable due to failures for more than 24 hours",
+    ]
+    assert not any(is_download_client_unreachable(m) for m in messages)
+
+
+def test_classify_arr_health_response_fails_on_download_client_message():
+    """The actual health handling branch must fail on a download client message.
+
+    Exercised through classify_arr_health_response, the same function
+    test_arr_health_response_empty calls, against a fabricated health
+    endpoint response rather than a live stack.
+    """
+    fabricated_response = [
+        {
+            "source": "QbittorrentSettingsValidator",
+            "type": "error",
+            "message": "Unable to communicate with QBittorrent. Connection refused",
+            "wikiUrl": "https://wiki.servarr.com/sonarr/system#download-client-unavailable",
+        },
+        {
+            "source": "IndexerRssCheck",
+            "type": "warning",
+            "message": "All indexers are unavailable due to failures",
+            "wikiUrl": "https://wiki.servarr.com/sonarr/system#indexers-are-unavailable",
+        },
+    ]
+    failures, warn_only = classify_arr_health_response(fabricated_response)
+    assert failures == ["Unable to communicate with QBittorrent. Connection refused"]
+    assert warn_only == ["All indexers are unavailable due to failures"]
+
+
+def test_classify_arr_health_response_warns_only_on_environmental_messages():
+    """A stack with no real indexers configured must only warn, not fail."""
     fabricated_response = [
         {
             "source": "IndexerRssCheck",
@@ -87,8 +121,12 @@ def test_is_download_client_unreachable_warns_on_environmental_messages():
             "wikiUrl": "https://wiki.servarr.com/sonarr/system#indexers-are-unavailable-due-to-failures",
         },
     ]
-    messages = [item["message"] for item in fabricated_response]
-    assert not any(is_download_client_unreachable(m) for m in messages)
+    failures, warn_only = classify_arr_health_response(fabricated_response)
+    assert failures == []
+    assert warn_only == [
+        "All indexers are unavailable due to failures",
+        "Indexers unavailable due to failures for more than 24 hours",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -123,14 +161,13 @@ def test_arr_health_response_empty(service_name, running_containers):
     # else, which stays a warning: most of what these endpoints report is
     # environmental (no indexers, no usenet provider, no real trackers
     # configured in a test environment) and turning all of it into a failure
-    # would make this tier useless. See is_download_client_unreachable in
-    # conftest.py for the fail list itself, and #124 for why this split exists.
+    # would make this tier useless. See classify_arr_health_response and
+    # is_download_client_unreachable in conftest.py for the fail list itself,
+    # and #124 for why this split exists.
     if data:
         import warnings
 
-        messages = [item.get("message", str(item)) for item in data]
-        failures = [m for m in messages if is_download_client_unreachable(m)]
-        warn_only = [m for m in messages if m not in failures]
+        failures, warn_only = classify_arr_health_response(data)
         if warn_only:
             warnings.warn(
                 f"{service_name} reports health issues: {warn_only}",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,6 +6,7 @@ import urllib3
 
 from conftest import (
     SERVICES,
+    is_download_client_unreachable,
     is_enabled,
     read_api_key,
     service_base_url,
@@ -48,6 +49,48 @@ def test_service_api_health(service_name, running_containers):
     )
 
 
+def test_is_download_client_unreachable_fails_on_download_client_messages():
+    """A download client message is the one thing this tier must fail on.
+
+    No live stack needed: this exercises the classification function directly
+    with the fabricated payload shape a real health endpoint returns, per #124.
+    """
+    fabricated_response = [
+        {
+            "source": "QbittorrentSettingsValidator",
+            "type": "error",
+            "message": "Unable to communicate with QBittorrent. Connection refused",
+            "wikiUrl": "https://wiki.servarr.com/sonarr/system#download-client-unavailable",
+        },
+    ]
+    messages = [item["message"] for item in fabricated_response]
+    assert any(is_download_client_unreachable(m) for m in messages)
+
+
+def test_is_download_client_unreachable_warns_on_environmental_messages():
+    """Environmental messages must not trip the fail list, per #124.
+
+    A stack with no real indexers configured is expected, not broken, and
+    this tier needs to keep passing against it.
+    """
+    fabricated_response = [
+        {
+            "source": "IndexerRssCheck",
+            "type": "warning",
+            "message": "All indexers are unavailable due to failures",
+            "wikiUrl": "https://wiki.servarr.com/sonarr/system#indexers-are-unavailable",
+        },
+        {
+            "source": "IndexerLongTermStatusCheck",
+            "type": "warning",
+            "message": "Indexers unavailable due to failures for more than 24 hours",
+            "wikiUrl": "https://wiki.servarr.com/sonarr/system#indexers-are-unavailable-due-to-failures",
+        },
+    ]
+    messages = [item["message"] for item in fabricated_response]
+    assert not any(is_download_client_unreachable(m) for m in messages)
+
+
 @pytest.mark.parametrize(
     "service_name",
     [
@@ -75,13 +118,25 @@ def test_arr_health_response_empty(service_name, running_containers):
     assert resp.status_code == 200
     data = resp.json()
     assert isinstance(data, list), f"Expected list from {url}, got {type(data)}"
-    # Warn about health issues rather than failing: some warnings are non-critical
+    # Split health issues into a short, explicit fail list (a download client
+    # is unreachable, which is a core function of this stack) and everything
+    # else, which stays a warning: most of what these endpoints report is
+    # environmental (no indexers, no usenet provider, no real trackers
+    # configured in a test environment) and turning all of it into a failure
+    # would make this tier useless. See is_download_client_unreachable in
+    # conftest.py for the fail list itself, and #124 for why this split exists.
     if data:
         import warnings
 
         messages = [item.get("message", str(item)) for item in data]
-        warnings.warn(
-            f"{service_name} reports health issues: {messages}",
-            UserWarning,
-            stacklevel=2,
+        failures = [m for m in messages if is_download_client_unreachable(m)]
+        warn_only = [m for m in messages if m not in failures]
+        if warn_only:
+            warnings.warn(
+                f"{service_name} reports health issues: {warn_only}",
+                UserWarning,
+                stacklevel=2,
+            )
+        assert not failures, (
+            f"{service_name} cannot reach a download client: {failures}"
         )


### PR DESCRIPTION
## What

`test_arr_health_response_empty` turned every servarr health message into a `UserWarning`, never a failure. That let a run where no arr could reach qBittorrent report all tests passed (#112), with the only trace being a warning nobody reads.

## Fix

Split health messages into a short, explicit fail list and everything else stays a warning.

The fail list (`DOWNLOAD_CLIENT_UNREACHABLE_SUBSTRINGS` in `tests/conftest.py`) matches messages that mean a download client (qBittorrent or SABnzbd) is unreachable, case insensitively. Each entry is commented with why it is there. Everything else, such as "All indexers are unavailable due to failures" in an environment with no real indexers, still only warns.

The matching logic lives in `is_download_client_unreachable(message)` in `tests/conftest.py`, next to the other test helper functions (`is_enabled`, `read_api_key`, etc), and is exercised directly by two unit tests in `tests/test_services.py` against fabricated health payloads, one that should fail and one that should still only warn. Those two tests need no live stack and pass locally.

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Health checks now distinguish between environmental warnings and unreachable download clients.
  - Non-critical environmental issues are reported as warnings, while communication failures with supported download clients are treated as failures.
  - Health checks now handle missing, malformed, or non-text health messages without errors.

- **Tests**
  - Added coverage for qBittorrent and SABnzbd connectivity failures.
  - Added coverage for environmental warnings and malformed health responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->