### PR TITLE
Reconcile stale download client hosts instead of skipping them

### DIFF
--- a/scripts/wire-connections.sh
+++ b/scripts/wire-connections.sh
@@ -841,7 +841,42 @@ ensure_qbittorrent_client() {
   existing=$(container_curl "$container" -sk --fail -H "X-Api-Key: ${api_key}" "$base_url" |
     jq 'map(select(.implementation == "QBittorrent")) | first')
   if [[ -n "$existing" && "$existing" != "null" ]]; then
-    echo "[$app_name] qBittorrent download client already exists, skipping."
+    # Found is not the same as correct: the host, and the port since it is
+    # set from config at creation the same way, can drift out from under an
+    # already wired client whenever GLUETUN_SERVICES_IP changes, for example
+    # a subnet change or a second checkout whose gateway differs (issue
+    # #112). Reconciling only when a stored value differs, rather than
+    # unconditionally, keeps a rerun quiet when nothing changed. The update
+    # payload is built from $existing itself, not the schema used for
+    # creation, so username and password stay exactly what the client
+    # already has instead of being read from files and resupplied here.
+    local existing_host existing_port
+    existing_host=$(jq -r '.fields[] | select(.name == "host") | .value' <<<"$existing")
+    existing_port=$(jq -r '.fields[] | select(.name == "port") | .value' <<<"$existing")
+    if [[ "$existing_host" == "$GLUETUN_SERVICES_IP" && "$existing_port" == "$QBITTORRENT_HTTPS_PORT" ]]; then
+      echo "[$app_name] qBittorrent download client already exists, skipping."
+      return 0
+    fi
+
+    echo "[$app_name] qBittorrent download client host/port stale (${existing_host}:${existing_port}), correcting to ${GLUETUN_SERVICES_IP}:${QBITTORRENT_HTTPS_PORT}..."
+    local id payload
+    id=$(jq -r '.id' <<<"$existing")
+    payload=$(jq \
+      --arg host "$GLUETUN_SERVICES_IP" \
+      --arg port "$QBITTORRENT_HTTPS_PORT" \
+      '.fields |= map(
+        if .name == "host" then .value = $host
+        elif .name == "port" then .value = ($port | tonumber)
+        else . end)' <<<"$existing")
+
+    local response
+    if ! response=$(container_curl "$container" -sk --fail -X PUT \
+      -H "X-Api-Key: ${api_key}" -H "Content-Type: application/json" \
+      -d "$payload" "${base_url}/${id}" 2>&1); then
+      echo "[$app_name] WARNING: failed to update qBittorrent download client host: ${response:0:300}"
+      return 1
+    fi
+    echo "[$app_name] Updated."
     return 0
   fi
 
@@ -897,7 +932,37 @@ ensure_sabnzbd_client() {
   existing=$(container_curl "$container" -sk --fail -H "X-Api-Key: ${api_key}" "$base_url" |
     jq 'map(select(.implementation == "Sabnzbd")) | first')
   if [[ -n "$existing" && "$existing" != "null" ]]; then
-    echo "[$app_name] SABnzbd download client already exists, skipping."
+    # See ensure_qbittorrent_client's matching comment: same drift, same
+    # reasoning for reconciling conditionally and for basing the update
+    # payload on $existing so its apiKey is preserved rather than reread and
+    # resupplied.
+    local existing_host existing_port
+    existing_host=$(jq -r '.fields[] | select(.name == "host") | .value' <<<"$existing")
+    existing_port=$(jq -r '.fields[] | select(.name == "port") | .value' <<<"$existing")
+    if [[ "$existing_host" == "$GLUETUN_SERVICES_IP" && "$existing_port" == "$SABNZBD_HTTP_PORT" ]]; then
+      echo "[$app_name] SABnzbd download client already exists, skipping."
+      return 0
+    fi
+
+    echo "[$app_name] SABnzbd download client host/port stale (${existing_host}:${existing_port}), correcting to ${GLUETUN_SERVICES_IP}:${SABNZBD_HTTP_PORT}..."
+    local id payload
+    id=$(jq -r '.id' <<<"$existing")
+    payload=$(jq \
+      --arg host "$GLUETUN_SERVICES_IP" \
+      --arg port "$SABNZBD_HTTP_PORT" \
+      '.fields |= map(
+        if .name == "host" then .value = $host
+        elif .name == "port" then .value = ($port | tonumber)
+        else . end)' <<<"$existing")
+
+    local response
+    if ! response=$(container_curl "$container" -sk --fail -X PUT \
+      -H "X-Api-Key: ${api_key}" -H "Content-Type: application/json" \
+      -d "$payload" "${base_url}/${id}" 2>&1); then # pragma: allowlist secret
+      echo "[$app_name] WARNING: failed to update SABnzbd download client host: ${response:0:300}"
+      return 1
+    fi
+    echo "[$app_name] Updated."
     return 0
   fi
 


### PR DESCRIPTION
Fixes #112.

## The bug

`ensure_qbittorrent_client` and `ensure_sabnzbd_client` in `scripts/wire-connections.sh` both returned early the moment they found an existing download client of that implementation on an arr. The host address was only ever written at creation time, so a `GLUETUN_SERVICES_IP` change (a subnet change, or a second checkout whose gateway differs) left every arr pointing at the stale address forever, and `make wire_connections` could not repair it.

## The fix

Both functions now reconcile instead of skipping outright:

- No existing client: create it, unchanged from before.
- Existing client found: compare its stored host and port against the currently configured `GLUETUN_SERVICES_IP` and port. If either differs, PUT an update to that client's record (`.../downloadclient/{id}`) correcting just those two fields. If both match, skip exactly as before, with the same log line.

I went with conditional reconciliation (only update when a stored value differs) rather than unconditional, since it keeps a rerun against an already correct client quiet instead of rewriting a working config on every invocation. The comparison is a plain string/value match against `GLUETUN_SERVICES_IP` and the relevant `*_PORT` variable, read out of the existing client's own `fields` array.

Port is included alongside host because the creation payload sets both from config the same way, so both can drift the same way. Nothing else in the payload is touched: the update payload is built by taking the existing client's own record (`$existing`, the same object the "does one exist" check already fetched) and overriding only the `host` and `port` fields, so username, password and API key are carried over exactly as they already are rather than being reread from secrets files and resupplied.

## Validation

Brought up the dev stack in an isolated second checkout (own `CONTAINER_PREFIX`, subnets and published ports so it did not collide with a deployment already running on the host), ran `make wire_connections` once to get a normal wired state, then simulated drift by forcing Sonarr's own qBittorrent and SABnzbd download clients' `host` field to a bogus address directly through Sonarr's API (`PUT .../downloadclient/{id}?forceSave=true`, since Sonarr's own validation refuses an unreachable host otherwise). Reran `make wire_connections` and confirmed through Sonarr's API that:

- Both clients' `host` field was corrected back to the configured `GLUETUN_SERVICES_IP`.
- `username`/`password` (qBittorrent) and `apiKey` (SABnzbd) were unchanged.
- A further rerun against the now correct clients logged only "already exists, skipping" for both, with no PUT issued.

Separately noticed, and did not touch since it is unrelated to this fix: `tests/test_wire_connections.py`'s `container_http` calls pass the bare service name instead of routing it through `container_name()`, so those tests target the wrong container whenever `CONTAINER_PREFIX` is non empty. It is latent in the default (empty prefix) case CI runs, which is why it has not surfaced there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing qBittorrent and SABnzbd download clients are now synchronized with current host and port settings.
  * Unchanged client configurations are skipped to avoid unnecessary updates.
  * Update failures are now reported clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->