### PR TITLE
Fix test_wire_connections.py to resolve container names through container_name()

### DIFF
--- a/tests/test_wire_connections.py
+++ b/tests/test_wire_connections.py
@@ -27,7 +27,14 @@ from datetime import UTC
 
 import pytest
 
-from conftest import ENV, REPO_ROOT, container_http, is_enabled, skip_if_not_running
+from conftest import (
+    ENV,
+    REPO_ROOT,
+    container_http,
+    container_name,
+    is_enabled,
+    skip_if_not_running,
+)
 
 pytestmark = pytest.mark.wiring
 
@@ -75,7 +82,7 @@ def _download_clients(app: str, running_containers: dict) -> list[dict]:
     scheme, port_var, api_ver, _ = ARR_APPS[app]
     port = _env(port_var)
     status, body = container_http(
-        app,
+        container_name(app),
         f"{scheme}://127.0.0.1:{port}/{app}/api/{api_ver}/downloadclient",
         headers={"X-Api-Key": _api_key(app)},
         timeout=TIMEOUT,
@@ -172,7 +179,7 @@ def _prowlarr_download_clients(running_containers) -> list[dict]:
     skip_if_not_running("prowlarr", running_containers)
     port = _env("PROWLARR_HTTPS_PORT")
     status, body = container_http(
-        "prowlarr",
+        container_name("prowlarr"),
         f"https://127.0.0.1:{port}/prowlarr/api/v1/downloadclient",
         headers={"X-Api-Key": _api_key("prowlarr")},
         timeout=TIMEOUT,
@@ -231,7 +238,7 @@ def test_prowlarr_flaresolverr_indexer_proxy_wired(running_containers):
     skip_if_not_running("prowlarr", running_containers)
     port = _env("PROWLARR_HTTPS_PORT")
     status, body = container_http(
-        "prowlarr",
+        container_name("prowlarr"),
         f"https://127.0.0.1:{port}/prowlarr/api/v1/indexerproxy",
         headers={"X-Api-Key": _api_key("prowlarr")},
         timeout=TIMEOUT,
@@ -250,7 +257,7 @@ def test_prowlarr_flaresolverr_indexer_proxy_wired(running_containers):
     )
 
     status, body = container_http(
-        "prowlarr",
+        container_name("prowlarr"),
         f"https://127.0.0.1:{port}/prowlarr/api/v1/tag",
         headers={"X-Api-Key": _api_key("prowlarr")},
         timeout=TIMEOUT,
@@ -273,7 +280,7 @@ def test_arr_host_prereqs_wired(app, running_containers):
     scheme, port_var, api_ver, _ = ARR_APPS[app]
     port = _env(port_var)
     status, body = container_http(
-        app,
+        container_name(app),
         f"{scheme}://127.0.0.1:{port}/{app}/api/{api_ver}/config/host",
         headers={"X-Api-Key": _api_key(app)},
         timeout=TIMEOUT,
@@ -292,7 +299,7 @@ def test_prowlarr_applications_wired(running_containers):
     skip_if_not_running("prowlarr", running_containers)
     port = _env("PROWLARR_HTTPS_PORT")
     status, body = container_http(
-        "prowlarr",
+        container_name("prowlarr"),
         f"https://127.0.0.1:{port}/prowlarr/api/v1/applications",
         headers={"X-Api-Key": _api_key("prowlarr")},
         timeout=TIMEOUT,
@@ -325,7 +332,7 @@ def test_prowlarr_indexer_wired(running_containers):
     skip_if_not_running("prowlarr", running_containers)
     port = _env("PROWLARR_HTTPS_PORT")
     status, body = container_http(
-        "prowlarr",
+        container_name("prowlarr"),
         f"https://127.0.0.1:{port}/prowlarr/api/v1/indexer",
         headers={"X-Api-Key": _api_key("prowlarr")},
         timeout=TIMEOUT,
@@ -382,7 +389,7 @@ def test_prowlarr_indexers_propagated_to_arr_app(app, running_containers):
     backoff_status = ""
     for attempt in range(4):
         status, body = container_http(
-            app,
+            container_name(app),
             f"{scheme}://127.0.0.1:{port}/{app}/api/{api_ver}/indexer",
             headers={"X-Api-Key": _api_key(app)},
             timeout=TIMEOUT,
@@ -393,7 +400,7 @@ def test_prowlarr_indexers_propagated_to_arr_app(app, running_containers):
             break
 
         status, body = container_http(
-            "prowlarr",
+            container_name("prowlarr"),
             f"https://127.0.0.1:{prowlarr_port}/prowlarr/api/v1/indexerstatus",
             headers={"X-Api-Key": _api_key("prowlarr")},
             timeout=TIMEOUT,
@@ -479,7 +486,7 @@ def _notifications(app: str, running_containers: dict) -> list[dict]:
     skip_if_not_running(app, running_containers)
     scheme, port_var, api_ver, _ = ARR_APPS[app]
     status, body = container_http(
-        app,
+        container_name(app),
         f"{scheme}://127.0.0.1:{_env(port_var)}/{app}/api/{api_ver}/notification",
         headers={"X-Api-Key": _api_key(app)},
         timeout=TIMEOUT,
@@ -493,7 +500,7 @@ def _supports_jellyfin(app: str, running_containers: dict) -> bool:
     skip_if_not_running(app, running_containers)
     scheme, port_var, api_ver, _ = ARR_APPS[app]
     status, body = container_http(
-        app,
+        container_name(app),
         f"{scheme}://127.0.0.1:{_env(port_var)}/{app}/api/{api_ver}/notification/schema",
         headers={"X-Api-Key": _api_key(app)},
         timeout=TIMEOUT,
@@ -556,7 +563,7 @@ def test_jellyfin_connection_points_at_a_reachable_jellyfin(app, running_contain
     )
 
     status, _ = container_http(
-        app,
+        container_name(app),
         f"http://{host}:{port}{_env('JELLYFIN_BASE_URL')}/System/Info/Public",
         timeout=TIMEOUT,
     )
@@ -606,7 +613,7 @@ def test_jellyfin_connection_passes_the_apps_own_test(app, running_containers):
 
     scheme, port_var, api_ver, _ = ARR_APPS[app]
     status, body = container_http(
-        app,
+        container_name(app),
         f"{scheme}://127.0.0.1:{_env(port_var)}/{app}/api/{api_ver}/notification/test",
         headers={"X-Api-Key": _api_key(app), "Content-Type": "application/json"},
         method="POST",


### PR DESCRIPTION
Fixes #166.

## The bug

Every `container_http()` call in `tests/test_wire_connections.py` passed a bare service name (`app`, `"prowlarr"`) straight through, instead of resolving it via `container_name()`, which is what applies `CONTAINER_PREFIX`. CI always runs with an empty prefix, where the bare name and the real container name are the same string, so this went unnoticed there. With a nonempty prefix (the documented way to run a second checkout beside an existing one), every call in this file targeted a container that either did not exist, or belonged to a different checkout entirely.

## The fix

Added `container_name` to this file's `conftest` import and wrapped every service name argument to `container_http()` with it (13 call sites), matching how `fresh_container` and `skip_if_not_running_fresh` already do this elsewhere in the suite.

## Validation

Ran live against an isolated stack (`CONTAINER_PREFIX=wtb166-`, its own `COMPOSE_PROJECT_NAME`, non colliding subnets/ports) beside an already running deployment on the same host:

- With the fix, 39 of 42 relevant tests in `tests/test_wire_connections.py -m wiring` passed, correctly reaching every `wtb166-*` prefixed container. The 3 failures were an unrelated, pre-existing readarr to qBittorrent authentication flake in that bootstrap run, not related to container naming.
- With the fix reverted (bare names) against the same prefixed stack, the tests that hit apps also present in the other, unrelated deployment (lidarr, prowlarr, etc.) got a 401 rather than failing to connect at all: the bare `podman exec` silently reached the other checkout's own container instead of the intended one, exactly the failure mode described in the issue.
- The empty prefix (CI exercised) path was not re run live: `container_name(x)` is `f"{CONTAINER_PREFIX}{service}"`, a strict identity when `CONTAINER_PREFIX` is empty, so there is no behavior difference between the old bare call and the new `container_name()` call in that case for code inspection to miss.

Isolated validation stack was fully torn down (`make stop_all` then `make down`) afterward, confirmed via project label filtering that only its own containers were affected, and that the other deployment on the host was untouched throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test container references to use container names for addressing.
  * Reformatted test imports for consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->