### PR TITLE
fix: stop config:recommended's tests glob from hiding tests/requirements.txt

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -185,6 +185,7 @@
     "deprecatedapienabled",
     "deprecatedapilocalhostonly",
     "deprecatedapiport",
+    "deprioritized",
     "dereferer",
     "Desat",
     "desync",

--- a/.env.example
+++ b/.env.example
@@ -400,7 +400,19 @@ SABNZBD_EXPORTER_VERSION=0.1.80@sha256:8404e51064aca68c533f3f56827c054f8eac3bad8
 SONARR_VERSION=4.0.19@sha256:c19aa4ecdf03d73e1d5c901da33744cb7eb4d921f89bafed1ca264601d7fa224
 # renovate: depName=docker.io/linuxserver/wireguard
 VPN_MOCK_VERSION=1.0.20260223-r0-ls119@sha256:ac43e1226878d2611315172d6ea357a95cb326ee73124b91108118efc8666889
-WHISPARR_VERSION=v3
+# Pinned by digest, not left tracking v3 directly. This digest is
+# v3-3.4.0-release.1387, the release hotio published right before
+# v3-3.5.0-release.1585 broke both the container healthcheck and the proxy
+# connectivity check here on 2026-09-09/10, three separate times.
+# v3-3.4.0-release.1387 had run clean for the five days before that.
+# Tried pinning to the release tag itself first, but loose versioning cannot
+# order v3-X.Y.Z-release.NNNN tags against each other: dry-run=lookup proposed
+# jumping straight back to v3's own current (broken) digest, which would have
+# auto-merged. The tag stays the bare v3 alias so there is no ordering to get
+# wrong; only the digest is what actually pins this. See
+# docs/DEPENDENCY_UPDATES.md, "Remaining gaps", for the full incident.
+# renovate: depName=ghcr.io/hotio/whisparr versioning=loose
+WHISPARR_VERSION=v3@sha256:5ef2becefe53327c0b67e41377329c933efd933ef59bdfb447f40d1439a6f3c4
 
 # Legacy app versions
 # renovate: depName=docker.io/linuxserver/jackett

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,9 @@
   // regex, since each already has one: `pre-commit` reads the hook `rev:` in
   // .pre-commit-config.yaml, `github-actions` reads workflow `uses:` versions,
   // and `pip_requirements` reads tests/requirements.txt. All three ship
-  // enabled by default except `pre-commit`, switched on below.
+  // enabled by default except `pre-commit`, switched on below, and
+  // `pip_requirements` needed the `ignorePaths` override below it to actually
+  // reach tests/requirements.txt at all.
   //
   // What remains a customManager, and why: Docker image versions pinned in
   // .env.example behind a `# renovate: depName=...` annotation, Python
@@ -31,6 +33,20 @@
   // leaving both live risked two managers proposing updates for the same
   // line.
   extends: ["config:recommended"],
+
+  // config:recommended pulls in config:ignoreModulesAndTests, whose
+  // ignorePaths includes **/tests/**, meant for a vendored fixture directory
+  // in a language ecosystem, not this repository's own tests/ directory,
+  // where tests/requirements.txt actually lives. Left in place, that pattern
+  // silently drops tests/requirements.txt from every manager repository
+  // wide before pip_requirements ever gets to look at it: confirmed live
+  // with a dry-run=extract, which shows no pip_requirements manager at all
+  // in the output despite it being enabled by default and the packageRule
+  // below naming it by file. ignorePaths cannot be scoped to one manager, so
+  // there is no narrower fix than overriding it repository wide back to
+  // Renovate's own bare default (node_modules, bower_components), which
+  // this repository has no use for either but which costs nothing to keep.
+  ignorePaths: ["**/node_modules/**", "**/bower_components/**"],
 
   // Kept on for its warnings, not for the overview of pending updates. Two
   // lookup failures sat unseen on Mend's hosted dashboard for weeks: nothing

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -43,22 +43,35 @@ on:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main
-  # For the `approve-owner` job below only. `Review Verified` is realistically
-  # the slowest of the six required contexts, since it waits on CodeRabbit's
-  # own review, and `pull_request_target` never fires again once a pull
-  # request stops changing. Without a second trigger, a pull request whose
-  # review finished after the first poll window closed would need a push it
-  # did not otherwise need, purely to get approved.
+  # For the `approve-owner` job below only. `pull_request_target` never fires
+  # again once a pull request stops changing, so a pull request whose last
+  # required context settles after the first poll window closed would need a
+  # push it did not otherwise need, purely to get approved.
   #
-  # `workflow_run`, not `status`: coderabbit-gate.yml publishes
-  # `Review Verified` with `secrets.GITHUB_TOKEN`, and GitHub does not start
-  # new workflow runs from events a `GITHUB_TOKEN` creates, so a `status`
-  # trigger would never fire from that publish at all, silently.
-  # `workflow_run` reacts to the run finishing rather than to the API call
-  # made during it, which is why it is the sanctioned way to chain workflows
-  # without a personal access token.
+  # Both CodeRabbit Gate and Integration Tests are named here, not just the
+  # first. `Review Verified` was assumed to be the slowest of the required
+  # contexts, since it waits on CodeRabbit's own review, but that is not true
+  # in practice: the integration suite Integration Tests runs routinely takes
+  # longer than a CodeRabbit review does, and #177 sat unapproved for exactly
+  # that reason on 2026-09-10. `Tests Verified` went green at 15:16 UTC, well
+  # after CodeRabbit Gate's own poll window had already closed and given up
+  # at 15:00, and nothing was listening for Integration Tests finishing to
+  # try again. The hourly schedule that should have caught it within the
+  # hour was itself skipped by GitHub, confirmed against the Actions API
+  # rather than assumed, which is the same "deprioritized under load" risk
+  # docs/MERGE_PIPELINE.md already documents for CodeRabbit Gate's own
+  # schedule. Naming both workflows here means whichever of the two required
+  # contexts actually finishes last is what re-triggers the poll, instead of
+  # depending on an assumption about which one that will be.
+  #
+  # `workflow_run`, not `status`: both workflows publish their status with
+  # `secrets.GITHUB_TOKEN`, and GitHub does not start new workflow runs from
+  # events a `GITHUB_TOKEN` creates, so a `status` trigger would never fire
+  # from either publish at all, silently. `workflow_run` reacts to the run
+  # finishing rather than to the API call made during it, which is why it is
+  # the sanctioned way to chain workflows without a personal access token.
   workflow_run:
-    workflows: ["CodeRabbit Gate"]
+    workflows: ["CodeRabbit Gate", "Integration Tests"]
     types: [completed]
   # The recovery lever, for the `nudge-bot` job below only. Neither
   # `pull_request_target` above fires again once a pull request stops

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -448,10 +448,28 @@ pins are deliberately fixed, not accidentally frozen.
 
 ## Remaining gaps
 
-Three tags are deliberately left floating rather than pinned to a version at all:
-`NGINX_VERSION=stable-alpine`, `PLEX_VERSION=latest`, and `WHISPARR_VERSION=v3`.
+Two tags are deliberately left floating rather than pinned to a version at all:
+`NGINX_VERSION=stable-alpine` and `PLEX_VERSION=latest`.
 `tests/test_renovate_pins.py` carries them in an explicit allowlist, so the exemption is a
 decision on the record rather than an omission.
+
+`WHISPARR_VERSION` used to be the third. `v3` tracks a floating alias hotio republishes
+whenever they rebuild, which they do off Whisparr's `eros` branch with no tagged releases
+of its own, upstream has nothing to point a stable tag at either. On 2026-09-09 hotio pushed
+`v3-3.5.0-release.1585` under that alias, and it broke both the container healthcheck and the
+proxy connectivity check here, three separate merge queue runs in a row, none of it caused by
+anything in this repository: `eros` itself had no real code commit since 2026-01-14, only
+translation updates since, so whatever broke lives in hotio's build layer, not the app.
+
+The fix doesn't need upstream to change anything, hotio already tags each build with an
+immutable version alongside the floating alias (`v3-3.4.0-release.1387`, `v3-3.5.0-release.1585`,
+and so on going back through `v3-3.2.0-release.27`), they just don't document those as the way
+to install this. `WHISPARR_VERSION` is now pinned to `v3-3.4.0-release.1387`'s digest, the
+release immediately before the broken one, which had run clean for five days before that.
+`versioning=loose` because the tag is not semver Renovate can order (`v3-` prefix, `-release.NNNN`
+suffix), the same reasoning as `LAZYLIBRARIAN_VERSION` below. Renovate will still offer a
+`digest` update whenever `v3` moves to a new build; confirm CI actually passes before taking
+one, this pin has no ordering to fall back on if a future one is bad again.
 
 `MYLAR_VERSION` carries no digest, and cannot as it stands. It is read twice out of one
 variable: as the base image the wrapper in `build/` is built on, and as the tag of the locally

--- a/tests/test_renovate_pins.py
+++ b/tests/test_renovate_pins.py
@@ -59,7 +59,6 @@ FLOATING = {
         "not in the default stack (PLEX_PROFILE=disabled); latest is also a "
         "channel tag with no digest to pin anyway"
     ),
-    "WHISPARR_VERSION": "v3 tracks the v3 branch, which upstream keeps moving",
 }
 
 # Annotated pins that must not carry a digest. Both are consumed twice, as the


### PR DESCRIPTION
## What

Renovate has never actually watched `tests/requirements.txt` since #170 retired Dependabot here, despite that pull request's own dry-run validation reporting full coverage. `config:recommended` pulls in `config:ignoreModulesAndTests`, whose `ignorePaths` includes `**/tests/**`, meant for a vendored fixture directory in a language ecosystem, not this repository's own `tests/` directory, where `tests/requirements.txt` actually lives. That pattern silently drops the file from every manager repository wide before `pip_requirements` ever gets to look at it.

## Evidence

Before this fix, `renovate --platform=local --dry-run=extract` shows no `pip_requirements` manager anywhere in the output, despite it shipping enabled by default and a `packageRule` in `renovate.json5` already naming it by file (`matchManagers: ["pip_requirements"]`). `LOG_LEVEL=debug` confirms `ignorePaths` containing `**/tests/**` is the cause.

## Fix

`ignorePaths` cannot be scoped to one manager, so the fix overrides it repository wide, back to Renovate's own bare default (`node_modules`, `bower_components`), which this repository has no use for either but which costs nothing to keep.

## Validation

`renovate --platform=local --dry-run=extract` after the fix: `pip_requirements` now reports one file, nine dependencies, matching `tests/requirements.txt` directly. Every other manager's file and dependency counts are unchanged (`asdf` 1/2, `docker-compose` 7/35, `dockerfile` 2/3, `github-actions` 7/41, `pre-commit` 1/13, `regex` 6/50).

Found while migrating a sibling repository (`pre-commit-checklists-demo`) off Dependabot and checking this repository for the same class of gap during that work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency scanning to include test requirement files, improving coverage for dependency updates.
  - Pinned Whisparr to a specific stable release digest to improve deployment reliability while continuing to receive tracked digest updates.
  - Improved automated merge checks so approval polling retries after required validation workflows complete.

- **Documentation**
  - Clarified dependency scanning behavior and configuration.
  - Updated dependency guidance to reflect Whisparr’s pinned release and the remaining floating image tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->