### PR TITLE
fix: recognize a first-time GitHub Actions pin as pin-only

### DIFF
--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -37,6 +37,15 @@ malicious. `checkov==3.3.2` becoming `checkov==3.3.11` is the change this file
 exists to permit, and no amount of diff reading can tell a good release from a
 backdoored one. That is what the cooling window in .github/renovate.json5, the
 integration suite, and the scanners are for. See docs/HARDENING.md.
+
+A first pin counts as a version moving too, not only a bump between two
+existing pins: `uses: actions/checkout@v7` becoming
+`uses: actions/checkout@<sha> # v7` is Renovate's `pinDigests` update type
+adding a SHA and a release comment where there was previously only a bare
+tag, which is exactly as safe to wave through as any other version moving in
+a pin position, for the same reason a first Docker image digest already is
+(see DIGEST below). #178 was refused before this normalized, despite being
+nothing else.
 """
 
 import re
@@ -113,6 +122,35 @@ def _normalize_action_sha(match: re.Match[str]) -> str:
     return ""
 
 
+# A first-time `pinDigests` bump on a GitHub Action changes
+# `uses: actions/checkout@v7` to `uses: actions/checkout@<sha> # v7` in one
+# step: there is no prior SHA to compare against, and the trailing release
+# comment appears for the first time alongside it. #178 proved this live,
+# refused by `Pin Only` despite being nothing but the pin Renovate's own
+# `pinDigests` update type exists to add.
+#
+# ACTION_SHA above normalizes the pinned side to " # <version>" whenever a
+# release comment trails the SHA, exactly what a first-time pin always
+# carries (Renovate never adds a bare SHA with no comment). This pattern
+# gives the unpinned side the identical placeholder, so the two sides of a
+# first-time pin compare equal the same way an ordinary SHA-to-SHA bump does.
+# It has to run before the generic VERSION fallback below, which would
+# otherwise normalize the bare form to `@<version>` instead, a shape the
+# pinned side can never produce and so could never match; ACTION_SHA already
+# ran first and would have consumed any line that has a SHA, so by the time
+# this pattern is tried, `@RELEASE$` can only mean a bare, unpinned ref.
+#
+# Anchored to end of line for the same reason ACTION_SHA is: a version token
+# followed by anything else is not this shape and is left alone, so it is
+# still read as a structural change if it differs between the two sides. The
+# dependency name stays literal to the left of the `@` exactly as with every
+# other pin type here, which is what still refuses
+# `actions/checkout@v7` becoming `attacker/checkout@v7`: normalizing the
+# common suffix both sides share does not touch the text that has to match
+# for the lines to be counted as the same pin.
+BARE_ACTION_VERSION = re.compile(r"@" + RELEASE + r"$")
+
+
 # A version-shaped token that sits where a pin sits, and nowhere else. The
 # prefix is what makes this narrow: matching any number on the line would accept
 # `PUID=1000` becoming `PUID=0`, or a `fetch-depth` moving, since both sides
@@ -171,6 +209,7 @@ def normalize(line: str, path: str = "") -> str:
     """Reduce a line to everything about it that a version bump may not change."""
     stripped = DIGEST.sub("", line)
     stripped = ACTION_SHA.sub(_normalize_action_sha, stripped)
+    stripped = BARE_ACTION_VERSION.sub(" # <version>", stripped)
     if path.endswith(".tool-versions"):
         return TOOL_VERSION_LINE.sub(r"\g<prefix><version>", stripped)
     return VERSION.sub(r"\g<prefix><version>", stripped)

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -148,7 +148,22 @@ def _normalize_action_sha(match: re.Match[str]) -> str:
 # `actions/checkout@v7` becoming `attacker/checkout@v7`: normalizing the
 # common suffix both sides share does not touch the text that has to match
 # for the lines to be counted as the same pin.
-BARE_ACTION_VERSION = re.compile(r"@" + RELEASE + r"$")
+#
+# Requires a `uses:` field and an owner/repo-shaped coordinate immediately
+# before the `@`, unlike ACTION_SHA above, which does not check for `uses:`
+# at all. A CodeRabbit review of this pull request found the gap an
+# unscoped version left: a `run:` step's `tool@v7` would normalize the same
+# way, so that line could grow an unrelated-looking SHA and comment and
+# still read as a first-time pin, on a file where a `run:` step is already
+# called out above as one of the two executable surfaces a path allowlist
+# alone would not fence. ACTION_SHA is left as it was rather than narrowed
+# to match: its shape (a 40 character hex run) is not one `run:` step
+# content plausibly produces by coincidence the way a short version tag is,
+# and narrowing an already-relied-on pattern belongs in its own change, not
+# folded into this one.
+BARE_ACTION_VERSION = re.compile(
+    r"(?P<action_prefix>\buses:[ \t]+[\w.-]+/[\w./-]+)@" + RELEASE + r"$"
+)
 
 
 # A version-shaped token that sits where a pin sits, and nowhere else. The
@@ -209,7 +224,7 @@ def normalize(line: str, path: str = "") -> str:
     """Reduce a line to everything about it that a version bump may not change."""
     stripped = DIGEST.sub("", line)
     stripped = ACTION_SHA.sub(_normalize_action_sha, stripped)
-    stripped = BARE_ACTION_VERSION.sub(" # <version>", stripped)
+    stripped = BARE_ACTION_VERSION.sub(r"\g<action_prefix> # <version>", stripped)
     if path.endswith(".tool-versions"):
         return TOOL_VERSION_LINE.sub(r"\g<prefix><version>", stripped)
     return VERSION.sub(r"\g<prefix><version>", stripped)

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -218,6 +218,23 @@ def test_refuses_a_first_time_pin_with_a_swapped_owner():
     assert result.returncode == 1
 
 
+def test_refuses_a_run_step_version_bump_disguised_as_a_first_time_pin():
+    # CodeRabbit's finding on this pull request: an unscoped version of
+    # BARE_ACTION_VERSION would let a run: step's trailing tool@v7 normalize
+    # the same way a first-time action pin does, so it could grow an
+    # unrelated-looking SHA and comment and still read as pin-only. Requiring
+    # a uses: field and an owner/repo coordinate immediately before the `@`
+    # closes that: this line has neither.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-          run: tool@v7\n"
+            "+          run: tool@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7\n",
+        )
+    )
+    assert result.returncode == 1
+
+
 def test_refuses_a_first_time_pin_missing_its_release_comment():
     # A bare SHA with nothing trailing it normalizes to "" (ACTION_SHA), not
     # to the " # <version>" a first-time pin's bare side produces, so the two

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -170,6 +170,71 @@ def test_refuses_a_comment_appearing_where_there_was_none():
 
 
 # ---------------------------------------------------------------------------
+# A first-time GitHub Actions pin normalizes with the bare ref it replaces
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_a_first_time_github_action_pin():
+    # #178: pinDigests adding a SHA and release comment to a previously
+    # unpinned action, refused before this normalized, despite being nothing
+    # but the pin Renovate's own update type exists to add.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-        uses: actions/checkout@v7\n"
+            "+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            " # v7\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_accepts_a_first_time_pin_alongside_a_tag_bump():
+    # The release comment does not have to match the old bare tag exactly;
+    # Renovate can pin straight to a newer release than the one that was
+    # sitting there unpinned, the same as an ordinary bump would.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-        uses: actions/checkout@v7\n"
+            "+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            " # v7.0.1\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_refuses_a_first_time_pin_with_a_swapped_owner():
+    # The dependency name stays literal to the left of the `@` for this shape
+    # exactly as it does for every other pin type here.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-        uses: actions/checkout@v7\n"
+            "+        uses: evil/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            " # v7\n",
+        )
+    )
+    assert result.returncode == 1
+
+
+def test_refuses_a_first_time_pin_missing_its_release_comment():
+    # A bare SHA with nothing trailing it normalizes to "" (ACTION_SHA), not
+    # to the " # <version>" a first-time pin's bare side produces, so the two
+    # still do not match: Renovate always adds the comment on this update
+    # type, and a diff missing it has changed something this script cannot
+    # account for as a plain pin.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-        uses: actions/checkout@v7\n"
+            "+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n",
+        )
+    )
+    assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
 # Refused: anything else, including alongside a legitimate bump
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Teaches `scripts/assert-pin-only-diff.py` a second GitHub Actions pin shape: a first-time `pinDigests` bump (`uses: actions/checkout@v7` becoming `uses: actions/checkout@<sha> # v7`), alongside the existing SHA-to-SHA bump shape it already recognized.

## Why

#178 proved this live: that PR's entire diff is six first-time SHA pins, nothing else, and `Pin Only` refused all of them because the script had no pattern for an unpinned bare tag becoming a SHA-pinned ref with a trailing release comment in one step. `Pin Only` is a required status check with no bypass actor configured on `main`, so that failure is permanent for a bot-authored PR: the diff shape never changes on retry. The only way to land #178 was to recreate its exact diff as a human-authored PR instead, which defeats the point of an unattended dependency pipeline for the one case (adopting SHA pinning on a newly-added action) it should least need a human for.

`ACTION_SHA` already normalizes a SHA pin's trailing release comment to ` # <version>` when one trails it, which is exactly what a first-time pin always carries. The new `BARE_ACTION_VERSION` pattern gives the unpinned side that identical placeholder, so both sides of a first-time pin compare equal the same way an ordinary SHA-to-SHA bump already does. It runs after `ACTION_SHA` (which will already have consumed any line that has a SHA) and before the generic `VERSION` fallback, so it only ever matches a genuinely bare, unpinned action ref.

The dependency name stays literal to the left of the `@` for this shape exactly as it does for every other pin type here, so `actions/checkout@v7` becoming `evil/checkout@<sha> # v7` is still refused, covered by a new test.

## Validation

- `python3 scripts/assert-pin-only-diff.py` against #178's actual diff: `Pin-only diff confirmed`, exit 0 (was exit 1 before this fix).
- Four new tests: accepts the first-time pin shape, accepts one alongside a tag bump, refuses a swapped owner on a first-time pin, refuses a first-time pin missing its release comment. All existing tests, including the swapped-owner and swapped-name regressions for the already-working SHA-bump shape, still pass.
- Full `pytest -m scripts`: 265 passed, 3 skipped.
- `pre-commit` push stage: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsgRbdzgYcgaoURvgfBvgd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change validation so only genuine GitHub Actions references are normalized during first-time pinning.
  * Prevented version strings in shell commands from being incorrectly treated as action pins.
  * Continued rejecting invalid pin updates, including changed action sources and missing version annotations.

* **Tests**
  * Added coverage for valid first-time pins, mismatched action sources, missing comments, and shell-command version changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->