### PR TITLE
fix: resolve zizmor findings on merge.yml blocking #178

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,6 +14,11 @@ jobs:
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Nothing in this job pushes or runs anything past the checkout
+          # itself, so the checked out credential has no reason to survive
+          # past this step.
+          persist-credentials: false
 
   create_tag:
     name: Create Tag
@@ -41,11 +46,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      # ncipollo/release-action wrapped exactly this: a release with a given
+      # body plus GitHub's own generated notes appended, nothing this
+      # repository used it for that gh does not already do. zizmor flags the
+      # action as superfluous for that reason (the runner ships gh
+      # preinstalled), and unlike rsync-crypt's use of the same action, this
+      # job never sets allowUpdates, the one option gh has no equivalent for,
+      # so there is no capability gap to keep the action around for.
+      # No checkout: gh release create talks to the API directly and never
+      # touches a local git tree, the same as the action it replaces, so
+      # GH_REPO stands in for the repository context a checkout would
+      # otherwise provide.
       - name: Create a GitHub release
-        id: create_release
-        uses: ncipollo/release-action@v1.21.0
-        with:
-          tag: ${{ needs.create_tag.outputs.new_tag }}
-          name: Release ${{ needs.create_tag.outputs.new_tag }}
-          body: ${{ needs.create_tag.outputs.changelog }}
-          generateReleaseNotes: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.create_tag.outputs.new_tag }}
+          NOTES: ${{ needs.create_tag.outputs.changelog }}
+        run: |
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --notes "$NOTES" \
+            --generate-notes


### PR DESCRIPTION
## What

Fixes the two zizmor / Code Scanning findings that surfaced on #178 and were blocking its merge under `required_conversation_resolution`.

## Why

Both findings appeared the moment Renovate opened #178, anchored on lines that PR's own pin bump touches:

- **`zizmor/artipacked`** (checkout job, line 16): `actions/checkout` ran with no `persist-credentials: false`. Nothing in this job pushes or runs anything past the checkout itself, so the credential had no reason to survive past that step.
- **`zizmor/superfluous-actions`** (create_release job): `ncipollo/release-action` wrapped exactly what `gh release create` already does here, a release with a given body plus generated notes appended. Unlike `rsync-crypt`'s use of the same action, this job never sets `allowUpdates`, the one option `gh` has no equivalent for, so there was no capability gap to keep the action around for.

These are pre-existing gaps in `merge.yml` unrelated to #178's own pin bump or to #183's `Pin Only` fix; they just happened to surface as new alerts because #178 is the first PR to touch those exact lines.

## Validation

- `zizmor .github/workflows/merge.yml` directly: both findings gone (only the two pre-existing `unpinned-uses` findings remain, which #178 itself resolves).
- `pre-commit`'s push stage (actionlint, yamllint, cspell, gitleaks, etc.): clean.
- `gh release create --help`: confirmed `--notes` combines with `--generate-notes` by prepending the given text to the auto-generated notes, the same concatenation `generateReleaseNotes: true` plus `body` produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsgRbdzgYcgaoURvgfBvgd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation for more consistent release creation and generated release notes.
  - Enhanced credential handling during automated workflows to reduce the risk of credentials persisting beyond required steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->