### PR TITLE
fix: anchor uses: to line start in the first-time pin pattern

### DIFF
--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -110,8 +110,17 @@ DIGEST = re.compile(r"@sha256:[0-9a-f]{7,}")
 # prefix of a longer hex run (a sha256 digest, in particular) from matching
 # and silently swallowing the character that would have made the shapes
 # differ.
+#
+# Case-insensitive (`[0-9a-fA-F]`, not `[0-9a-f]`): GitHub resolves a
+# `uses:` SHA the same way regardless of case, so an uppercase or
+# mixed-case SHA is just as real a pin as a lowercase one, and matching
+# only lowercase left a gap a CodeRabbit review of BARE_ACTION_VERSION
+# below found: an uppercase SHA on a first-time pin's new side fell
+# through ACTION_SHA entirely and was accepted by BARE_ACTION_VERSION's
+# generic RELEASE grammar instead, which does not check that a
+# first-time pin's target is SHA-shaped at all.
 ACTION_SHA = re.compile(
-    r"@[0-9a-f]{40}(?![0-9a-fA-F])(?P<comment>[ \t]+#[ \t]*" + RELEASE + r")?$"
+    r"@[0-9a-fA-F]{40}(?![0-9a-fA-F])(?P<comment>[ \t]+#[ \t]*" + RELEASE + r")?$"
 )
 
 
@@ -172,11 +181,32 @@ def _normalize_action_sha(match: re.Match[str]) -> str:
 # Anchored to the start of the line instead, with only an optional YAML
 # list marker (`- `) and indentation in front of `uses:`, which is the only
 # place a real `uses:` field can sit.
+#
+# The version is its own capture group, `bare_version`, rather than folded
+# unnamed into the match, because a third CodeRabbit-class finding (found by
+# extending their own test, not reported directly) showed RELEASE alone is
+# still too permissive here: `_normalize_bare_action_version` below refuses
+# a 40 character match outright, real hex or not, because 40 characters is
+# the shape ACTION_SHA exists to own exclusively. Without that check, a
+# non-hex 40 character token, `0` followed by 39 `z`s for instance, never
+# matches ACTION_SHA (not hex) and was accepted here instead, since nothing
+# about this pattern's own grammar checked that the "version" replacing a
+# first-time pin's bare tag was ever a real SHA at all, only that it was
+# RELEASE-shaped. A real first-time pin's target is always exactly a 40
+# character SHA, ACTION_SHA's exclusive domain, so anything that length
+# reaching this pattern instead is already suspect, and refusing it outright
+# costs nothing: a length that long never occurs in a genuine bare release
+# tag either.
 BARE_ACTION_VERSION = re.compile(
     r"(?P<action_prefix>^(?:[ \t]*-[ \t]+)?[ \t]*uses:[ \t]+[\w.-]+/[\w./-]+)@"
-    + RELEASE
-    + r"$"
+    r"(?P<bare_version>" + RELEASE + r")$"
 )
+
+
+def _normalize_bare_action_version(match: re.Match[str]) -> str:
+    if len(match.group("bare_version")) == 40:
+        return match.group(0)
+    return f"{match.group('action_prefix')} # <version>"
 
 
 # A version-shaped token that sits where a pin sits, and nowhere else. The
@@ -237,7 +267,7 @@ def normalize(line: str, path: str = "") -> str:
     """Reduce a line to everything about it that a version bump may not change."""
     stripped = DIGEST.sub("", line)
     stripped = ACTION_SHA.sub(_normalize_action_sha, stripped)
-    stripped = BARE_ACTION_VERSION.sub(r"\g<action_prefix> # <version>", stripped)
+    stripped = BARE_ACTION_VERSION.sub(_normalize_bare_action_version, stripped)
     if path.endswith(".tool-versions"):
         return TOOL_VERSION_LINE.sub(r"\g<prefix><version>", stripped)
     return VERSION.sub(r"\g<prefix><version>", stripped)

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -305,7 +305,8 @@ ACTION_REF_VERSION = re.compile(
 
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 
-# A YAML block scalar opener: `key: |`, `key: >`, with the optional
+# A YAML block scalar opener: `key: |`, `key: >`, or a bare sequence item
+# whose own value is the scalar (`- |`, `- >-`), with the optional
 # chomping (`-`/`+`) and explicit indentation (a digit) modifiers the spec
 # allows, in either order (`|2-` and `|-2` are both valid YAML), and an
 # optional trailing comment after them. Everything indented more than a
@@ -320,13 +321,17 @@ FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 # approves. A later review round found the first regex here only matched
 # one modifier order and no trailing comment, so `run: |2-  # step body`
 # or `run: |-2` opened a block scalar this check could not recognize as
-# one. Deliberately not applied to VERSION below: its own `@` prefix
-# already covers a pip pin's `pkg==1.2.3` living inside a `run:` step by
-# design (see VERSION's own comment), a legitimate shape in this
-# repository's workflows that a block scalar check must not cost its
-# normalization.
+# one. A further review found it still missed a standalone sequence-item
+# scalar header, `- |` with no `key:` in front at all, since the pattern
+# required a colon before the scalar indicator; confirmed exploitable the
+# same way, a `uses:` line nested under one read as ordinary YAML
+# structure instead of a block scalar's literal content. Deliberately not
+# applied to VERSION below: its own `@` prefix already covers a pip pin's
+# `pkg==1.2.3` living inside a `run:` step by design (see VERSION's own
+# comment), a legitimate shape in this repository's workflows that a
+# block scalar check must not cost its normalization.
 BLOCK_SCALAR_OPENER = re.compile(
-    r":\s*[|>](?:[+-][1-9]?|[1-9][+-]?)?(?:[ \t]+#.*)?\s*$"
+    r"(?::|^[ \t]*-)\s*[|>](?:[+-][1-9]?|[1-9][+-]?)?(?:[ \t]+#.*)?\s*$"
 )
 
 

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -289,7 +289,19 @@ VERSION = re.compile(
 # at all). `.env.example`'s own `@` usage is a Docker image digest, and
 # DIGEST above already removes that entirely before this pattern ever
 # runs, so nothing here needs an `.env.example` case to stay working.
-ACTION_REF_VERSION = re.compile(r"(?P<prefix>@)[0-9A-Za-z][0-9A-Za-z.+_-]*")
+#
+# Anchored to a genuine `uses:` field at the start of the line, the same
+# anchor ACTION_SHA and BARE_ACTION_VERSION use, rather than a bare `@`
+# matched anywhere: a CodeRabbit review found the block scalar gating
+# above was not enough on its own, because this pattern's own unscoped
+# `@` still matched a plain, single-line `run:` step's own text once
+# outside a block scalar, `run: echo fake/action@v7` becoming
+# `run: echo fake/action@v8` in particular, with no `uses:` field
+# involved at all. Confirmed exploitable before this anchor was added.
+ACTION_REF_VERSION = re.compile(
+    r"(?P<prefix>^(?:[ \t]*-[ \t]+)?[ \t]*uses:[ \t]+[\w.-]+/[\w./-]+)"
+    r"@[0-9A-Za-z][0-9A-Za-z.+_-]*$"
+)
 
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 
@@ -374,7 +386,7 @@ def normalize(line: str, path: str = "", in_block_scalar: bool = False) -> str:
     if not (in_block_scalar and path.startswith(".github/workflows/")):
         stripped = ACTION_SHA.sub(_normalize_action_sha, stripped)
         stripped = BARE_ACTION_VERSION.sub(_normalize_bare_action_version, stripped)
-        stripped = ACTION_REF_VERSION.sub(r"\g<prefix><version>", stripped)
+        stripped = ACTION_REF_VERSION.sub(r"\g<prefix>@<version>", stripped)
     if path.endswith(".tool-versions"):
         return TOOL_VERSION_LINE.sub(r"\g<prefix><version>", stripped)
     return VERSION.sub(r"\g<prefix><version>", stripped)

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -119,16 +119,26 @@ DIGEST = re.compile(r"@sha256:[0-9a-f]{7,}")
 # through ACTION_SHA entirely and was accepted by BARE_ACTION_VERSION's
 # generic RELEASE grammar instead, which does not check that a
 # first-time pin's target is SHA-shaped at all.
+#
+# Anchored to a genuine `uses:` field at the start of the line, the same
+# anchor BARE_ACTION_VERSION uses, rather than a bare `@<sha>` matched
+# anywhere: a follow-up CodeRabbit finding pointed out the original,
+# unanchored ACTION_SHA matched a 40 character hex run on ANY changed
+# workflow line, `run:` step content included, so a `run:` command could
+# change while its normalized form stayed equal, as long as the line
+# still ended in something SHA-shaped.
 ACTION_SHA = re.compile(
+    r"(?P<uses_prefix>^(?:[ \t]*-[ \t]+)?[ \t]*uses:[ \t]+[\w.-]+/[\w./-]+)"
     r"@[0-9a-fA-F]{40}(?![0-9a-fA-F])(?P<comment>[ \t]+#[ \t]*" + RELEASE + r")?$"
 )
 
 
 def _normalize_action_sha(match: re.Match[str]) -> str:
     """Strip a `@<sha>` action pin, normalizing its trailing release comment."""
+    prefix = match.group("uses_prefix")
     if match.group("comment"):
-        return " # <version>"
-    return ""
+        return f"{prefix} # <version>"
+    return prefix
 
 
 # A first-time `pinDigests` bump on a GitHub Action changes
@@ -255,19 +265,91 @@ def _normalize_bare_action_version(match: re.Match[str]) -> str:
 # `checkov==3.3.2` becoming `evil==3.3.2`. What a bump is allowed to change is
 # the value in a pin position, and only there, which is why `PUID=1000` is
 # untouched by this and a change to it is refused.
+#
+# `@` is deliberately not one of the prefixes here, unlike the five that
+# are: it is a separate pattern below, ACTION_REF_VERSION, gated by block
+# scalar status the same way ACTION_SHA and BARE_ACTION_VERSION are. This
+# regex used to carry `@` directly, and a block scalar review found the
+# gap that left: skipping ACTION_SHA and BARE_ACTION_VERSION for a line
+# inside a run: | block did not stop that line being treated as a pin at
+# all, since this regex's own unscoped `@` still matched it independently.
+# Confirmed exploitable: `uses: fake/action@v7` becoming
+# `uses: fake/action@v8` inside a run: | block still read as Pin-only
+# before this split, even with the block scalar check already in place.
 VERSION = re.compile(
-    r"(?P<prefix>==|>=|@|(?<=VERSION)=|\brev:[ \t]+|(?<=\S):)"
+    r"(?P<prefix>==|>=|(?<=VERSION)=|\brev:[ \t]+|(?<=\S):)"
     r"[0-9A-Za-z][0-9A-Za-z.+_-]*"
 )
 
+# The `@` case VERSION used to carry directly: an action ref that is not a
+# SHA pin at all, either a first-time pin's bare, unpinned side (`@v7`,
+# handled together with the pinned side by BARE_ACTION_VERSION when it is
+# not inside a block scalar) or a floating tag moving to another floating
+# tag (`@v7` becoming `@v7.1.0`, an action that has never been SHA-pinned
+# at all). `.env.example`'s own `@` usage is a Docker image digest, and
+# DIGEST above already removes that entirely before this pattern ever
+# runs, so nothing here needs an `.env.example` case to stay working.
+ACTION_REF_VERSION = re.compile(r"(?P<prefix>@)[0-9A-Za-z][0-9A-Za-z.+_-]*")
+
 FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 
+# A YAML block scalar opener: `key: |`, `key: >`, with the optional
+# chomping (`-`/`+`) and explicit indentation (a digit) modifiers the spec
+# allows. Everything indented more than a line matching this, until a line
+# at or below its own indentation appears, is that block scalar's literal
+# content, not further YAML structure: a `run: |` step body is the shape
+# that matters here, since its content can coincidentally read exactly
+# like a `uses:` field. A CodeRabbit review found and confirmed this: an
+# indented `uses: owner/action@<sha> # v7` inside a run: | block matched
+# ACTION_SHA and BARE_ACTION_VERSION alike, treating shell text as if it
+# were a real GitHub Actions step, which a required check reading `Pin
+# Only` then approves. Deliberately not applied to VERSION below: its own
+# `@` prefix already covers a pip pin's `pkg==1.2.3` living inside a
+# `run:` step by design (see VERSION's own comment), a legitimate shape
+# in this repository's workflows that a block scalar check must not cost
+# its normalization.
+BLOCK_SCALAR_OPENER = re.compile(r":\s*[|>][+-]?[1-9]?\s*$")
 
-def normalize(line: str, path: str = "") -> str:
+
+def _line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" \t"))
+
+
+def _in_block_scalar(context: list[str], indent: int) -> bool:
+    """Judge, from the lines already seen in this file's diff, whether
+    `indent` sits inside an open YAML block scalar.
+
+    Scans backward for the nearest line indented less than `indent`,
+    skipping blank lines (a block scalar can itself contain one, and its
+    zero indentation must not be mistaken for the boundary that closes the
+    scalar). Inside a block scalar if that nearer line opens one.
+    Conservatively also inside one if no such line is visible at all: the
+    diff is all this script ever sees of the file around a change, so a
+    block scalar whose own opening line sits outside the diff's context
+    cannot be told apart from one that was never open, and refusing the
+    line as a candidate pin either way is the fail closed direction, the
+    same one every other shape in this file takes when it cannot be sure.
+    """
+    for seen in reversed(context):
+        if not seen.strip():
+            continue
+        if _line_indent(seen) < indent:
+            return bool(BLOCK_SCALAR_OPENER.search(seen))
+    return True
+
+
+def normalize(line: str, path: str = "", in_block_scalar: bool = False) -> str:
     """Reduce a line to everything about it that a version bump may not change."""
     stripped = DIGEST.sub("", line)
-    stripped = ACTION_SHA.sub(_normalize_action_sha, stripped)
-    stripped = BARE_ACTION_VERSION.sub(_normalize_bare_action_version, stripped)
+    # Scoped to .github/workflows/: nothing else here (.env.example,
+    # .tool-versions) has a YAML block scalar to be inside. Every `@`
+    # pattern is gated together, since ACTION_REF_VERSION is the same
+    # unpinned-action-ref shape BARE_ACTION_VERSION and ACTION_SHA cover,
+    # just without a first-time pin's SHA on the other side.
+    if not (in_block_scalar and path.startswith(".github/workflows/")):
+        stripped = ACTION_SHA.sub(_normalize_action_sha, stripped)
+        stripped = BARE_ACTION_VERSION.sub(_normalize_bare_action_version, stripped)
+        stripped = ACTION_REF_VERSION.sub(r"\g<prefix><version>", stripped)
     if path.endswith(".tool-versions"):
         return TOOL_VERSION_LINE.sub(r"\g<prefix><version>", stripped)
     return VERSION.sub(r"\g<prefix><version>", stripped)
@@ -279,6 +361,15 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
     structural: list[str] = []
     path = None
     in_hunk = False
+    # The lines of each side of this file seen so far in the diff, in file
+    # order: what a block scalar check has to work with, since the diff
+    # never carries the whole file. Kept separate because a hunk can add or
+    # remove a block scalar's own opening line, which changes whether a
+    # later line on just one side is inside one. Reset on every file header,
+    # not every hunk, since hunks in one file's diff always appear in
+    # ascending line order and a block scalar can span more than one hunk.
+    old_context: list[str] = []
+    new_context: list[str] = []
 
     for line in diff.splitlines():
         header = FILE_HEADER.match(line)
@@ -286,6 +377,8 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
             old, new = header.group("old"), header.group("new")
             path = new
             in_hunk = False
+            old_context = []
+            new_context = []
             changes.setdefault(path, (Counter(), Counter()))
             if old != new:
                 structural.append(f"{old} renamed to {new}")
@@ -311,9 +404,22 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
             continue
 
         if line.startswith("-"):
-            changes[path][0][normalize(line[1:], path)] += 1
+            content = line[1:]
+            in_scalar = _in_block_scalar(old_context, _line_indent(content))
+            changes[path][0][normalize(content, path, in_scalar)] += 1
+            old_context.append(content)
         elif line.startswith("+"):
-            changes[path][1][normalize(line[1:], path)] += 1
+            content = line[1:]
+            in_scalar = _in_block_scalar(new_context, _line_indent(content))
+            changes[path][1][normalize(content, path, in_scalar)] += 1
+            new_context.append(content)
+        elif line.startswith(" ") or line == "":
+            # An unchanged context line: not compared itself, but part of
+            # the surrounding structure a block scalar check on a later
+            # line in this file needs to see.
+            content = line[1:] if line else line
+            old_context.append(content)
+            new_context.append(content)
 
     return changes, structural
 

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -295,20 +295,27 @@ FILE_HEADER = re.compile(r"^diff --git a/(?P<old>.+) b/(?P<new>.+)$")
 
 # A YAML block scalar opener: `key: |`, `key: >`, with the optional
 # chomping (`-`/`+`) and explicit indentation (a digit) modifiers the spec
-# allows. Everything indented more than a line matching this, until a line
-# at or below its own indentation appears, is that block scalar's literal
-# content, not further YAML structure: a `run: |` step body is the shape
-# that matters here, since its content can coincidentally read exactly
-# like a `uses:` field. A CodeRabbit review found and confirmed this: an
-# indented `uses: owner/action@<sha> # v7` inside a run: | block matched
-# ACTION_SHA and BARE_ACTION_VERSION alike, treating shell text as if it
-# were a real GitHub Actions step, which a required check reading `Pin
-# Only` then approves. Deliberately not applied to VERSION below: its own
-# `@` prefix already covers a pip pin's `pkg==1.2.3` living inside a
-# `run:` step by design (see VERSION's own comment), a legitimate shape
-# in this repository's workflows that a block scalar check must not cost
-# its normalization.
-BLOCK_SCALAR_OPENER = re.compile(r":\s*[|>][+-]?[1-9]?\s*$")
+# allows, in either order (`|2-` and `|-2` are both valid YAML), and an
+# optional trailing comment after them. Everything indented more than a
+# line matching this, until a line at or below its own indentation
+# appears, is that block scalar's literal content, not further YAML
+# structure: a `run: |` step body is the shape that matters here, since
+# its content can coincidentally read exactly like a `uses:` field. A
+# CodeRabbit review found and confirmed this: an indented `uses:
+# owner/action@<sha> # v7` inside a run: | block matched ACTION_SHA and
+# BARE_ACTION_VERSION alike, treating shell text as if it were a real
+# GitHub Actions step, which a required check reading `Pin Only` then
+# approves. A later review round found the first regex here only matched
+# one modifier order and no trailing comment, so `run: |2-  # step body`
+# or `run: |-2` opened a block scalar this check could not recognize as
+# one. Deliberately not applied to VERSION below: its own `@` prefix
+# already covers a pip pin's `pkg==1.2.3` living inside a `run:` step by
+# design (see VERSION's own comment), a legitimate shape in this
+# repository's workflows that a block scalar check must not cost its
+# normalization.
+BLOCK_SCALAR_OPENER = re.compile(
+    r":\s*[|>](?:[+-][1-9]?|[1-9][+-]?)?(?:[ \t]+#.*)?\s*$"
+)
 
 
 def _line_indent(line: str) -> int:
@@ -329,6 +336,24 @@ def _in_block_scalar(context: list[str], indent: int) -> bool:
     cannot be told apart from one that was never open, and refusing the
     line as a candidate pin either way is the fail closed direction, the
     same one every other shape in this file takes when it cannot be sure.
+
+    A CodeRabbit review named the residual gap in this precisely: the
+    first shallower line found is trusted as the boundary even when it is
+    itself ordinary scalar content one level further out, rather than the
+    real opener sitting deeper in the scan, so a `uses:` line nested under
+    something like an `if` inside a `run: |` block, both indented past the
+    block's own floor, is not caught. Scanning past a shallower non-opener
+    line to keep looking, rather than trusting it as decisive, would close
+    that gap, but was tried and reverted: it also requires reaching the
+    file's own top level (indentation zero) before a real diff's limited
+    context ever earns a confident "not inside one", and no ordinary `gh
+    pr diff` output carries that much. Verified against #178's own real
+    diff, which never contains the change's enclosing indentation chain
+    down to indentation zero: the deeper version refused it outright, the
+    same result a compromised bot's diff should get, not a clean one.
+    This narrower version is the one actually deployed; the nested case
+    above is an accepted, documented gap rather than a silently unfixed
+    one.
     """
     for seen in reversed(context):
         if not seen.strip():
@@ -361,13 +386,21 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
     structural: list[str] = []
     path = None
     in_hunk = False
-    # The lines of each side of this file seen so far in the diff, in file
-    # order: what a block scalar check has to work with, since the diff
-    # never carries the whole file. Kept separate because a hunk can add or
-    # remove a block scalar's own opening line, which changes whether a
-    # later line on just one side is inside one. Reset on every file header,
-    # not every hunk, since hunks in one file's diff always appear in
-    # ascending line order and a block scalar can span more than one hunk.
+    # The lines of each side of this file seen so far in the current hunk,
+    # in file order: what a block scalar check has to work with, since the
+    # diff never carries the whole file. Kept separate because a hunk can
+    # add or remove a block scalar's own opening line, which changes
+    # whether a later line on just one side is inside one. Reset on every
+    # hunk header, not only every file header: a hunk boundary means the
+    # diff skips lines in between, and a line just past the gap could
+    # otherwise be judged against context from before it, a shallower line
+    # left over from the previous hunk that is not actually the nearest
+    # one to the real file. Kept context from the file's earlier hunks
+    # cannot be trusted to still be the true boundary once the diff has
+    # jumped past lines neither side of this comparison ever saw; starting
+    # each hunk with nothing visible falls back to the same fail closed
+    # default `_in_block_scalar` already takes when a file's first hunk
+    # opens with no context at all.
     old_context: list[str] = []
     new_context: list[str] = []
 
@@ -386,6 +419,8 @@ def parse(diff: str) -> tuple[dict[str, tuple[Counter, Counter]], list[str]]:
 
         if line.startswith("@@"):
             in_hunk = True
+            old_context = []
+            new_context = []
             continue
 
         # Everything between a file header and its first hunk is preamble: the

--- a/scripts/assert-pin-only-diff.py
+++ b/scripts/assert-pin-only-diff.py
@@ -161,8 +161,21 @@ def _normalize_action_sha(match: re.Match[str]) -> str:
 # content plausibly produces by coincidence the way a short version tag is,
 # and narrowing an already-relied-on pattern belongs in its own change, not
 # folded into this one.
+#
+# `uses:` alone was not narrow enough either, as a follow-up CodeRabbit
+# finding on this exact pattern (ported to other repositories in this
+# family) went on to show: `\buses:` is a word-boundary check, not a
+# position check, so it matched the substring "uses:" anywhere a line
+# contains it, including inside a `run:` step's own text
+# (`run: uses: actions/checkout@v7` normalized the same way a real `uses:`
+# line did, and was confirmed to slip past this check before this fix).
+# Anchored to the start of the line instead, with only an optional YAML
+# list marker (`- `) and indentation in front of `uses:`, which is the only
+# place a real `uses:` field can sit.
 BARE_ACTION_VERSION = re.compile(
-    r"(?P<action_prefix>\buses:[ \t]+[\w.-]+/[\w./-]+)@" + RELEASE + r"$"
+    r"(?P<action_prefix>^(?:[ \t]*-[ \t]+)?[ \t]*uses:[ \t]+[\w.-]+/[\w./-]+)@"
+    + RELEASE
+    + r"$"
 )
 
 

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -204,6 +204,37 @@ def test_accepts_a_first_time_pin_alongside_a_tag_bump():
     assert result.returncode == 0, result.stdout
 
 
+def test_accepts_an_uppercase_first_time_pin():
+    # GitHub resolves a uses: SHA the same way regardless of case.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-        uses: actions/checkout@v7\n"
+            "+        uses: actions/checkout@3D3C42E5AAC5BA805825DA76410C181273BA90B1"
+            " # v7\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_refuses_a_non_hex_40_character_token_as_a_first_time_pin():
+    # A third finding on this pattern: RELEASE accepts any alphanumeric
+    # run, hex or not, so a 40 character token that is not real hex slips
+    # past ACTION_SHA (not hex) and was accepted here regardless, since
+    # nothing checked that a first-time pin's target was ever a real SHA.
+    # 40 characters is the shape ACTION_SHA exists to own exclusively, so
+    # anything that length reaching this pattern is refused outright.
+    fake = "0" + "z" * 39
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            f"-        uses: actions/checkout@v7\n"
+            f"+        uses: actions/checkout@{fake} # v7\n",
+        )
+    )
+    assert result.returncode == 1
+
+
 def test_refuses_a_first_time_pin_with_a_swapped_owner():
     # The dependency name stays literal to the left of the `@` for this shape
     # exactly as it does for every other pin type here.

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -660,3 +660,22 @@ def test_accepts_a_floating_tag_bump_outside_a_block_scalar():
         )
     )
     assert result.returncode == 0, result.stdout
+
+
+def test_refuses_an_action_ref_disguise_outside_a_block_scalar():
+    # A CodeRabbit review found ACTION_REF_VERSION itself was still
+    # unscoped: its own bare `@` prefix matched anywhere on a line, block
+    # scalar or not, so a plain single-line `run:` step's own text with
+    # an `@version`-shaped token normalized the same way a real `uses:`
+    # field does, with no block scalar and no `uses:` field involved at
+    # all. Confirmed exploitable before ACTION_REF_VERSION was anchored
+    # to a genuine `uses:` field: this exact diff read as Pin-only.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "      - name: Run\n"
+            "-        run: echo fake/action@v7\n"
+            "+        run: echo fake/action@v8\n",
+        )
+    )
+    assert result.returncode == 1

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -100,10 +100,14 @@ def test_accepts_a_hook_rev_bump():
 def test_accepts_a_github_action_sha_and_comment_bump():
     # The bug this guards: the dependency bot rewrites both halves on a real
     # bump, so the comment moving from `# v7` to `# v7.0.1` alongside the SHA
-    # must not read as a structural change.
+    # must not read as a structural change. The leading `- name:` line is
+    # real diff context, mirroring what `gh pr diff` always carries: without
+    # it, _in_block_scalar has nothing to judge from and conservatively
+    # refuses.
     result = _check(
         _diff(
             ".github/workflows/coderabbit-gate.yml",
+            "       - name: Checkout\n"
             "-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7\n"
             "+        uses: actions/checkout@f7dd8b1f9e0d1c9a1e0e5a3b0e0f0a0b0c0d0e0f # v7.0.1\n",
         )
@@ -117,6 +121,7 @@ def test_accepts_a_github_action_sha_only_bump():
     result = _check(
         _diff(
             ".github/workflows/coderabbit-gate.yml",
+            "       - name: Checkout\n"
             "-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7\n"
             "+        uses: actions/checkout@f7dd8b1f9e0d1c9a1e0e5a3b0e0f0a0b0c0d0e0f # v7\n",
         )
@@ -181,6 +186,7 @@ def test_accepts_a_first_time_github_action_pin():
     result = _check(
         _diff(
             ".github/workflows/pull-request-validation.yml",
+            "       - name: Checkout\n"
             "-        uses: actions/checkout@v7\n"
             "+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
             " # v7\n",
@@ -196,6 +202,7 @@ def test_accepts_a_first_time_pin_alongside_a_tag_bump():
     result = _check(
         _diff(
             ".github/workflows/pull-request-validation.yml",
+            "       - name: Checkout\n"
             "-        uses: actions/checkout@v7\n"
             "+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
             " # v7.0.1\n",
@@ -209,6 +216,7 @@ def test_accepts_an_uppercase_first_time_pin():
     result = _check(
         _diff(
             ".github/workflows/pull-request-validation.yml",
+            "       - name: Checkout\n"
             "-        uses: actions/checkout@v7\n"
             "+        uses: actions/checkout@3D3C42E5AAC5BA805825DA76410C181273BA90B1"
             " # v7\n",
@@ -256,12 +264,30 @@ def test_accepts_a_first_time_pin_as_a_yaml_list_item():
     result = _check(
         _diff(
             ".github/workflows/pull-request-validation.yml",
+            "     steps:\n"
             "-      - uses: actions/checkout@v7\n"
             "+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
             " # v7\n",
         )
     )
     assert result.returncode == 0, result.stdout
+
+
+def test_refuses_a_first_time_pin_with_no_visible_context():
+    # _in_block_scalar has nothing to judge from when the diff shows no
+    # line shallower than the change at all (a synthetic edge case a real
+    # gh pr diff essentially never produces, since it always carries a
+    # line or two of context), and conservatively refuses rather than
+    # guess, the same fail closed direction every other shape here takes.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-        uses: actions/checkout@v7\n"
+            "+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            " # v7\n",
+        )
+    )
+    assert result.returncode == 1
 
 
 def test_refuses_uses_embedded_in_a_run_step_disguised_as_a_first_time_pin():
@@ -554,3 +580,83 @@ def test_refuses_a_floor_pin_becoming_an_exact_pin():
     # difference even when the package and the version are both plausible.
     result = _check(_diff("tests/requirements.txt", "-json5>=0.12.1\n+json5==0.15.0\n"))
     assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# A uses: line inside a run: | block scalar is not a real GitHub Actions
+# field, and no pattern here may treat it as a pin
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_a_first_time_pin_disguise_inside_a_run_step():
+    # A CodeRabbit review found and confirmed this: normalize() has no YAML
+    # awareness, so an indented uses: line inside a run: | block, plain
+    # shell text, matched ACTION_SHA and BARE_ACTION_VERSION the same way a
+    # real GitHub Actions uses: field does.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "       - name: Something\n"
+            "         run: |\n"
+            "           echo hello\n"
+            "-          uses: fake/action@v7\n"
+            "+          uses: fake/action@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            " # v7\n",
+        )
+    )
+    assert result.returncode == 1
+
+
+def test_refuses_a_bare_tag_disguise_inside_a_run_step():
+    # A second gap the same review surfaced: skipping ACTION_SHA and
+    # BARE_ACTION_VERSION for a block scalar line was not enough on its
+    # own here, because VERSION's own @ prefix independently matched the
+    # same uses: owner/repo@version shape, with no SHA or comment
+    # involved at all. Confirmed exploitable before ACTION_REF_VERSION
+    # split that prefix out and gated it the same way: this exact diff
+    # read as Pin-only.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "       - name: Something\n"
+            "         run: |\n"
+            "           echo hello\n"
+            "-          uses: fake/action@v7\n"
+            "+          uses: fake/action@v8\n",
+        )
+    )
+    assert result.returncode == 1
+
+
+def test_accepts_a_pip_pin_bump_inside_a_block_scalar_run_step():
+    # The block scalar check must not cost this repository's own
+    # documented shape: a pip pin bump legitimately lives inside a run: |
+    # step (see VERSION's own comment), and has nothing to do with the
+    # uses: disguise the check above exists to catch.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "      - name: Install\n"
+            "        run: |\n"
+            "-          pip install checkov==3.3.2\n"
+            "+          pip install checkov==3.3.11\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_accepts_a_floating_tag_bump_outside_a_block_scalar():
+    # An action that has never been SHA-pinned can still move from one
+    # floating tag to another; ACTION_REF_VERSION covers this ordinary
+    # case (distinct from a first-time pin, which BARE_ACTION_VERSION
+    # covers), and it is not inside a block scalar here, so it still
+    # normalizes and accepts.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "      - name: Checkout\n"
+            "-        uses: actions/checkout@v7\n"
+            "+        uses: actions/checkout@v7.1.0\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -218,6 +218,38 @@ def test_refuses_a_first_time_pin_with_a_swapped_owner():
     assert result.returncode == 1
 
 
+def test_accepts_a_first_time_pin_as_a_yaml_list_item():
+    # A step is also legally written as a bare list item, `- uses: ...`,
+    # with no name: line above it. The anchor has to allow the optional
+    # marker, not just plain indentation.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-      - uses: actions/checkout@v7\n"
+            "+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            " # v7\n",
+        )
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_refuses_uses_embedded_in_a_run_step_disguised_as_a_first_time_pin():
+    # A follow-up CodeRabbit finding on this exact pattern: \buses: is a
+    # word-boundary check, not a position check, so it matched the
+    # substring "uses:" anywhere on the line, including inside a run:
+    # step's own text. Confirmed exploitable before this fix: this exact
+    # diff normalized as Pin-only.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "-          run: uses: actions/checkout@v7\n"
+            "+          run: uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            " # v7\n",
+        )
+    )
+    assert result.returncode == 1
+
+
 def test_refuses_a_run_step_version_bump_disguised_as_a_first_time_pin():
     # CodeRabbit's finding on this pull request: an unscoped version of
     # BARE_ACTION_VERSION would let a run: step's trailing tool@v7 normalize

--- a/tests/test_assert_pin_only_diff.py
+++ b/tests/test_assert_pin_only_diff.py
@@ -679,3 +679,23 @@ def test_refuses_an_action_ref_disguise_outside_a_block_scalar():
         )
     )
     assert result.returncode == 1
+
+
+def test_refuses_a_first_time_pin_disguise_inside_a_sequence_item_scalar():
+    # A CodeRabbit review found BLOCK_SCALAR_OPENER itself was still too
+    # narrow: it required a colon before the scalar indicator, so a bare
+    # sequence-item header with no key in front, `- |`, was not
+    # recognized as opening a block scalar. A uses: line nested under one
+    # then reached pin normalization as ordinary YAML structure instead
+    # of literal block scalar content. Confirmed exploitable before
+    # BLOCK_SCALAR_OPENER also matched a standalone sequence-item header.
+    result = _check(
+        _diff(
+            ".github/workflows/pull-request-validation.yml",
+            "        scripts:\n"
+            "          - |\n"
+            "-            uses: fake/action@v7\n"
+            "+            uses: fake/action@v8\n",
+        )
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
## What

Anchors `BARE_ACTION_VERSION` to the start of the line (with an optional YAML list marker), rather than requiring the substring `uses:` to merely appear somewhere on it.

## Why

A follow-up CodeRabbit review, on this pattern after it was ported to `rsync-crypt`, `github-template` and `pre-commit-checklists`, found that `\buses:` is a word-boundary check, not a position check. It matches "uses:" anywhere a line contains it, including inside a `run:` step's own text. Confirmed exploitable before this fix: `run: uses: actions/checkout@v7` becoming `run: uses: actions/checkout@<sha> # v7` normalized as `Pin-only diff confirmed`, on a file this script's own docstring already calls out as an executable surface a path allowlist alone would not fence.

Same fix already landed on `rsync-crypt`, `github-template` and `pre-commit-checklists-demo`; `pre-commit-checklists` in progress.

## Validation

Two new tests: the `run:` disguise using the literal text `uses:` refused, and a first-time pin written as a bare YAML list item (`- uses: ...`) still accepted, since the anchor now depends on line shape in a way it did not before. Full `pytest -m scripts` (268 passed, 3 skipped) and `pre-commit`'s push stage, both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsgRbdzgYcgaoURvgfBvgd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub Actions pin validation for indented and list-formatted `uses:` entries.
  - Added support for uppercase and mixed-case 40-character SHA pins.
  - Prevented `uses:` text inside command blocks from being misinterpreted as pin changes.
  - Correctly handles action-like text in YAML block scalars and rejects invalid first-time pins.
  - Added handling for bare sequence-item block scalars.

- **Tests**
  - Expanded coverage for context-free changes, embedded command text, list items, block scalars, and invalid SHA-like tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->