### PR TITLE
fix: make CITATION.cff valid CFF, and cover it with hooks

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -134,6 +134,7 @@
     "Celeron",
     "certfile",
     "cfduid",
+    "cffconvert",
     "cgroupfs",
     "Chamele",
     "changeme",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,51 @@ repos:
       - id: yamllint
         exclude: *app_managed
 
+      # CITATION.cff is YAML, but `identify` tags it only `text`, since the
+      # tag comes from the extension and `.cff` is not one it knows. The
+      # hook's own manifest carries `types: [file, yaml]`, so the entry above
+      # never sees the file and nothing else here does either. A second entry
+      # with `types:` overridden is the way in; it cannot be done from a
+      # consumer's selector alone.
+      #
+      # Worth covering because GitHub reads the file for the "Cite this
+      # repository" widget, where a file it cannot use produces nothing at
+      # all rather than an error anyone would see.
+      - id: yamllint
+        name: yamllint (CITATION.cff)
+        files: ^CITATION\.cff$
+        types: [text]
+
+  # The other half of that check: the Citation File Format schema itself,
+  # which yamllint knows nothing about. Not a theoretical gap. The author
+  # block in this file used to read `name:` and `url:`, and `url` is not a key
+  # CFF has at all (the person and entity definitions both spell it
+  # `website`), so the file had never been valid while parsing as YAML
+  # perfectly well the whole time. yamllint alone would have gone on passing
+  # it.
+  #
+  # cffconvert is the reference implementation's own validator. A repo: local
+  # hook because it ships no `.pre-commit-hooks.yaml` of its own, which is
+  # what the annotation below is for: the native pre-commit manager only
+  # updates a `rev:`, so the customManager in .github/renovate.json5 that
+  # reads an annotated `additional_dependencies` is what keeps this pin
+  # moving.
+  #
+  # pass_filenames is false with the path written out because cffconvert takes
+  # its input through `-i` and rejects a bare positional argument, so an
+  # appended filename would fail the hook on a valid file. `files:` still
+  # scopes it to that one file.
+  - repo: local
+    hooks:
+      - id: cffconvert-validate
+        name: Validate CITATION.cff against the CFF schema
+        language: python
+        # renovate: datasource=pypi depName=cffconvert
+        additional_dependencies: ["cffconvert==2.0.0"]
+        entry: cffconvert --validate -i CITATION.cff
+        files: ^CITATION\.cff$
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.5
     hooks:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,3 +1,4 @@
+---
 cff-version: 1.2.0
 message: >
   If you use this software, entirely or partially, directly or as inspiration,
@@ -8,9 +9,10 @@ abstract: >
   Routes selected services through a single Gluetun VPN gateway with a structural
   network namespace killswitch and reverse proxy access through Nginx.
 authors:
-  - name: Ivan Pinatti
+  - given-names: Ivan
+    family-names: Pinatti
     alias: ivan-pinatti
-    url: https://github.com/ivan-pinatti
+    website: https://github.com/ivan-pinatti
 license: Apache-2.0
 repository-code: https://github.com/ivan-pinatti-labs/docker-torrent-box-with-vpn
 url: https://github.com/ivan-pinatti-labs/docker-torrent-box-with-vpn


### PR DESCRIPTION
Ported from ivan-pinatti-labs/rsync-crypt#93, where this defect was first found.
ivan-pinatti-labs/github-template#20 fixes the same thing in the template, which
is where all three copies came from.

## The defect

```yaml
authors:
  - name: Ivan Pinatti        # entity-only key
    alias: ivan-pinatti
    url: https://github.com/ivan-pinatti   # not a CFF key at all
```

`url` does not exist in the Citation File Format; both the person and the entity
definition spell it `website`. The file was therefore never valid. GitHub reads
it for the "Cite this repository" widget, where an unusable file produces
nothing rather than an error anyone would see.

Rewritten as a person, which is what it describes:

```yaml
authors:
  - given-names: Ivan
    family-names: Pinatti
    alias: ivan-pinatti
    website: https://github.com/ivan-pinatti
```

## Why nothing caught it

Two separate reasons, and both needed fixing:

1. **No hook saw the file.** It is YAML, but `identify` tags it only `text`
   (the tag comes from the extension), and yamllint's own manifest carries
   `types: [file, yaml]`, which pre-commit ANDs with whatever a consumer asks
   for. The existing `adrienverge/yamllint` entry therefore never received it.
   A second entry with `types:` overridden is the way in; it cannot be done
   from a selector alone.
2. **yamllint would not have caught it anyway.** The file parsed perfectly
   well. The schema half is `cffconvert --validate`, the reference
   implementation's own validator, added as a `repo: local` hook since it ships
   no `.pre-commit-hooks.yaml`.

The cffconvert pin carries a `# renovate: datasource=pypi depName=cffconvert`
annotation, so the existing customManager for annotated
`additional_dependencies` tracks it rather than leaving it to rot.

## Verification

- `pre-commit run --all-files`: everything passes, including both new hooks.
- The new schema hook is not decorative: run against the previous author block
  it fails with `Additional properties are not allowed ('url', 'name' were
  unexpected)`.
- Also added `---` to the top of `CITATION.cff`, matching every other YAML file
  here, and `cffconvert` to `.cspell.json`'s `words`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated citation metadata to use a more structured author format and standardized website information.
  * Revised the citation file’s opening metadata for improved compatibility with citation tools.

* **Chores**
  * Added automated checks to validate citation metadata formatting and schema compliance.
  * Updated spelling configuration to recognize citation-tool terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->