### PR TITLE
fix: run checklist-dev-make in CI, not only on local commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -528,8 +528,14 @@ repos:
   # Reads checkmake.ini at the repo root. The .PHONY declaration in the
   # Makefile has to stay one per line; the comment above it says why.
   # See the library's docs/hook-catalogue.md, "Makefile linting".
+  # No `stages:` key, deliberately. The Code Check job runs
+  # `pre-commit run --all-files --hook-stage pre-push`, and a hook that names
+  # `stages: [pre-commit]` is excluded from that selection, so it would run on
+  # a local commit and never once in CI. That is what this entry did when it
+  # landed in #189: `checkmake` was configured, green, and checking nothing on
+  # every pull request. The `no-commit-to-branch` hook above is the one place
+  # `stages: [pre-commit]` is correct, and its own comment says why.
   - repo: https://github.com/ivan-pinatti-labs/pre-commit-checklists
     rev: v2.3.0
     hooks:
       - id: checklist-dev-make
-        stages: [pre-commit]


### PR DESCRIPTION
#189 wired up `checklist-dev-make` and it has not run in CI once.

## What happened

I gave the hook `stages: [pre-commit]`, copying the shape used elsewhere. The `Code Check` job runs:

```yaml
- name: Pre-commit Run
  uses: pre-commit/action@...
  with:
    extra_args: --all-files --hook-stage pre-push
```

A hook that explicitly names `stages: [pre-commit]` is excluded from a `--hook-stage pre-push` selection. The workflow's own comment states the design plainly:

> A hook with no `stages` key runs at every stage, so this selects all of them

I read that comment while writing #189 and still added the key.

## Evidence

`#189`'s own `Code Check` log has no trace of the hook. Locally:

```
$ pre-commit run --all-files --hook-stage pre-push | grep -i 'Makefile Checklist'
(nothing)
```

So the hook was configured, green, and checking nothing on every pull request. That is the same defect shape as a `types:`/`files:` selector matching no files, which this repo and the checklist library have both been bitten by before: a hook that checks nothing exits 0 and looks identical to a hook that passed.

## The fix

Drop the key so it runs at every stage, which is how every other hook here that belongs in CI is written. `no-commit-to-branch` keeps `stages: [pre-commit]` and is the one correct use, for the reason its own comment gives: at pre-push it would fire in CI where a `workflow_dispatch` run can legally sit on main, failing the gate for the wrong reason. That reasoning does not apply to a Makefile linter.

## Verification

Not just "it passes", since a passing hook is exactly what the bug looked like:

- Runs and passes at the pre-push stage (the CI selection) and at pre-commit.
- Appending an undeclared bodyless target to the Makefile **fails** it at the pre-push stage with `phonydeclared  Target "broken_shortcut"`, so it is gating rather than merely present.

## Scope

Only this repository. `rsync-crypt` and `pre-commit-checklists` both run plain `pre-commit run --all-files`, which selects the pre-commit stage, so `stages: [pre-commit]` is correct there; confirmed the hook ran and passed in both their CI logs.

`Pre-commit` is a required context in those two repos. Here the equivalent required context is `Code Check`, which is why this was easy to miss when comparing the two protection configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated validation checks to run during pre-push checks across all files.
  - Added comments clarifying when these checks are selected and run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->